### PR TITLE
SLC6: added libcurl-devel

### DIFF
--- a/slc6-builder/Dockerfile
+++ b/slc6-builder/Dockerfile
@@ -1,4 +1,4 @@
-# alisw/slc6-builder:v10
+# alisw/slc6-builder:v11
 
 FROM centos:centos6
 
@@ -19,7 +19,7 @@ RUN \
   mesa-libGLU-devel mpfr mpfr-devel openssl-devel perl-ExtUtils-Embed perl-libwww-perl python-devel \
   python-yaml redhat-lsb rpm-build screen subversion tcl tcsh tk wget which zip zlib-devel zsh \
   compat-libgfortran-41 python-argparse zip flex bison texinfo glibc-devel.i686 libgcc.i686 \
-  glibc-devel.x86_64 libgcc.i686 libgcc.x86_64 ncurses-devel && \
+  glibc-devel.x86_64 libgcc.i686 libgcc.x86_64 ncurses-devel libcurl-devel && \
   yum clean all && \
   ln -nfs /usr/bin/ccache /usr/local/bin/gcc && \
   ln -nfs /usr/bin/ccache /usr/local/bin/g++ && \


### PR DESCRIPTION
This closes #19 as well. Image already pushed on Docker Hub.