### PR TITLE
An rsync server to be used to serve and store packages.

### DIFF
--- a/rsync/Dockerfile
+++ b/rsync/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos:centos7
+
+# Patch redhat-release: pretend to be SLC7
+RUN yum update -y && yum install -y rsync
+ADD run.sh /run.sh
+
+CMD sh -ex /run.sh

--- a/rsync/run.sh
+++ b/rsync/run.sh
@@ -1,0 +1,23 @@
+VOLUME=/data/store
+ALLOW=${ALLOW:-192.168.0.0/16 172.16.0.0/12}
+OWNER=${OWNER:-root}
+GROUP=${GROUP:-root}
+
+#chown "${OWNER}:${GROUP}" "${VOLUME}"
+
+mkdir -p $VOLUME
+cat <<EOF > /etc/rsyncd.conf
+uid = ${OWNER}
+gid = ${GROUP}
+use chroot = yes
+pid file = /var/run/rsyncd.pid
+log file = /dev/stdout
+[store]
+    hosts deny = *
+    hosts allow = ${ALLOW}
+    read only = false
+    path = ${VOLUME}
+EOF
+
+cat /etc/rsyncd.conf
+exec /usr/bin/rsync --no-detach --daemon --config /etc/rsyncd.conf "$@"


### PR DESCRIPTION
Now that alibuild supports getting already built tarballs from elsewhere we can
use an rsync server so that different builders in the build cluster can share
build products. Notice this is passwordless as we assume that no one but the builders
can actually reach it.