### PR TITLE
Add mesos cluster name to startup options.

### DIFF
--- a/mesos-master/run.sh
+++ b/mesos-master/run.sh
@@ -3,4 +3,5 @@ mesos-master --zk=${MESOS_MASTER_ZK-zk://localhost:2181/mesos} \
              --quorum=${QUORUM-1} \
              --work_dir=${MESOS_MASTER_WORKDIR-/var/lib/mesos} \
              --log_dir=${MESOS_LOG_DIR-/var/log/mesos} \
-             --port=${MESOS_MASTER_PORT-5050}
+             --port=${MESOS_MASTER_PORT-5050} \
+             --cluster=${MESOS_CLUSTER-mesos}


### PR DESCRIPTION
Datadog integration crashes without it.