### PR TITLE
Install fpm on modern builders

### DIFF
--- a/slc6-builder/Dockerfile
+++ b/slc6-builder/Dockerfile
@@ -20,3 +20,5 @@ RUN \
   glibc-devel.x86_64 libgcc.i686 libgcc.x86_64 ncurses-devel libcurl-devel expat expat-devel \
   vim-enhanced valgrind gdb swig && \
   yum clean all
+RUN yum install -y rubygems ruby-devel
+RUN gem install --no-ri --no-rdoc fpm

--- a/slc7-builder/Dockerfile
+++ b/slc7-builder/Dockerfile
@@ -17,3 +17,5 @@ RUN \
     autoconf libxml2-devel openssl-devel libcurl-devel bzip2-devel mesa-libGLU-devel zip \
     perl-libwww-perl svn cvs flex bison texinfo glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 \
     libgcc.x86_64 ncurses-devel vim-enhanced gdb valgrind swig
+RUN yum install -y rubygems ruby-devel
+RUN gem install --no-ri --no-rdoc fpm

--- a/ubuntu1404-builder/Dockerfile
+++ b/ubuntu1404-builder/Dockerfile
@@ -15,3 +15,6 @@ RUN \
     bc time libbz2-dev python-dev python-yaml libcurl4-openssl-dev \
     flex bison swig screen tcl tk zip unzip zsh texinfo libncurses5-dev vim-nox valgrind gdb && \
   apt-get --yes --force-yes clean
+
+RUN apt-get --yes install ruby-dev build-essential
+RUN gem install --no-ri --no-rdoc fpm


### PR DESCRIPTION
SLC5 is not in this commit because it needs a more recent
ruby to build fpm.