### PR TITLE
No need to specify default option

### DIFF
--- a/mesos-slave/run.sh
+++ b/mesos-slave/run.sh
@@ -4,9 +4,9 @@
 #
 # Notice that in case of a frontend, we expose port 53 as well
 # as a valid resource.
+groupadd -g ${JENKINS_GID:-2000} jenkins
+useradd -u ${JENKINS_UID:-501} -g ${JENKINS_GID:-2000} jenkins
 mesos-slave --master=${MESOS_MASTER_ZK-zk://localhost:2181/mesos}                \
              --work_dir=${MESOS_MASTER_WORKDIR-/var/lib/mesos}                   \
              ${MESOS_SLAVE_FRONTEND+--resources='ports(*):[31000-32000, 53-53]'} \
-             --containerizers=docker,mesos                                       \
-             ${MESOS_ATTRIBUTES+--attributes=$MESOS_ATTRIBUTES}                  \
-             --port=${MESOS_SLAVE_PORT-5051}
+             --containerizers=docker,mesos


### PR DESCRIPTION
Mesos now supports passing them as environment, via MESOS_OPTION_NAME.