### PR TITLE
Add logstash-igprof

### DIFF
--- a/logstash-igprof/Dockerfile
+++ b/logstash-igprof/Dockerfile
@@ -1,0 +1,7 @@
+FROM logstash
+
+RUN mkdir -p /opt/logstash/patterns/igprof-io/
+ADD igprof-io-patterns.conf /opt/logstash/patterns/igprof-io/
+ADD logstash.conf /
+
+CMD logstash -f /logstash.conf

--- a/logstash-igprof/logstash.conf
+++ b/logstash-igprof/logstash.conf
@@ -1,0 +1,16 @@
+input { 
+  redis { 
+    host      => "redis.marathon.mesos"
+    port      => "6379"
+    key       => "igprof_files"
+    data_type => "list"
+  }
+}
+
+output {
+  elasticsearch_http {
+    host => "elasticsearch-client.marathon.mesos"
+    port => "9200"
+    index => "igprof-%{+YYYY.MM.dd}"
+  }
+}


### PR DESCRIPTION
logstash-igprof is an igprof-instance which retrieves information from
a REDIS instance populated with igprof information and pushes it to
elasticsearch, eventually filtering it as required.