### PR TITLE
add installation of environment-modules to allow usage of aliModules

### DIFF
--- a/slc5-builder/Dockerfile
+++ b/slc5-builder/Dockerfile
@@ -32,3 +32,4 @@ RUN \
   cd / && rm -rf /tmp/rpmswig && \
   yum clean all && \
   easy_install argparse
+RUN yum install -y environment-modules

--- a/slc6-builder/Dockerfile
+++ b/slc6-builder/Dockerfile
@@ -26,3 +26,4 @@ RUN rpm --rebuilddb && \
     rpm --import http://apt.sw.be/RPM-GPG-KEY.dag.txt && \
     yum install -y http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
     yum install -y git --enablerepo=rpmforge-extras
+RUN yum install -y environment-modules

--- a/slc7-builder/Dockerfile
+++ b/slc7-builder/Dockerfile
@@ -19,3 +19,4 @@ RUN \
     libgcc.x86_64 ncurses-devel vim-enhanced gdb valgrind swig
 RUN yum install -y rubygems ruby-devel
 RUN gem install --no-ri --no-rdoc fpm
+RUN yum install -y environment-modules


### PR DESCRIPTION
I added the installation of environment-modules for the SLC 5/6 and CC 7 builders, as a new RUN command at the end in order not to invalidate the previous stages.