### PR TITLE
Add mysql-devel to SLC5

### DIFF
--- a/slc5-builder/Dockerfile
+++ b/slc5-builder/Dockerfile
@@ -33,3 +33,4 @@ RUN \
   yum clean all && \
   easy_install argparse
 RUN rpm --rebuilddb && yum install -y environment-modules
+RUN rm -f /var/lib/rpm/Pubkeys && rpm --rebuilddb && yum install -y mysql-devel


### PR DESCRIPTION
Note the `rm` part which is unfortunately needed because of [this](http://www.redhat.com/archives/rpm-list/2003-December/msg00118.html)...