### PR TITLE
Add [vault](https://www.vaultproject.io) image

### DIFF
--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -1,0 +1,7 @@
+FROM alisw/slc7-builder
+
+ADD https://releases.hashicorp.com/vault/0.4.1/vault_0.4.1_linux_amd64.zip /vault.zip
+ADD run.sh /run.sh
+RUN unzip /vault.zip && ls
+
+CMD /bin/sh -e -x /run.sh

--- a/vault/run.sh
+++ b/vault/run.sh
@@ -1,0 +1,16 @@
+cat <<EOF >/vault.config
+backend "zookeeper" {
+  address = "127.0.0.1:2181"
+  path = "vault"
+  advertise_addr = "${ZOOKEEPER_ADDRESS:-zk://127.0.0.1:2181}"
+}
+
+listener "tcp" {
+  address = "0.0.0.0:8200"
+  tls_disable = 1
+}
+EOF
+
+[[ ! $DEBUG ]] && HAS_CONFIG=true
+
+/vault server ${HAS_CONFIG:+-config /vault.config} ${DEBUG:+-dev}


### PR DESCRIPTION
This is not yet ready for prime time, but it should provide a working
development environment, provided you set the `DEBUG` environment
variable. If DEBUG is not set you can use the ZOOKEEPER_ADDRESS variable
to have a permanent store on zookeeper. Notice that for the moment we do
not have a proper SSL setup so usage in production is not a good idea.