### PR TITLE
Add TLS variables to vault

### DIFF
--- a/vault/run.sh
+++ b/vault/run.sh
@@ -7,7 +7,9 @@ backend "zookeeper" {
 
 listener "tcp" {
   address = "0.0.0.0:8200"
-  tls_disable = 1
+  ${TLS_CERT_FILE:-tls_disable = 1}
+  ${TLS_CERT_FILE:+tls_cert_file = "${TLS_CERT_FILE}"}
+  ${TLS_KEY_FILE:+tls_key_file = "${TLS_KEY_FILE}"}
 }
 EOF
 


### PR DESCRIPTION
Allow passing TLS_CERT_FILE and TLS_KEY_FILE to vault.