### PR TITLE
Add https://vaultproject.io to containers

### DIFF
--- a/jekyll/Dockerfile
+++ b/jekyll/Dockerfile
@@ -4,6 +4,9 @@ RUN yum update -y && yum install -y ruby ruby-devel rubygems
 RUN yum update -y && yum install -y make gcc
 RUN gem install jekyll
 RUN yum update -y && yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-RUN yum install -y nodejs git java-1.8.0-openjdk
-RUN yum install -y python-pip vim
+RUN yum install -y nodejs git java-1.8.0-openjdk python-pip vim unzip jq
+
+ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
+RUN unzip vault.zip && mv ./vault /usr/bin/vault
+
 RUN pip install elasticsearch elasticsearch-dsl PyYAML

--- a/slc5-builder/Dockerfile
+++ b/slc5-builder/Dockerfile
@@ -28,7 +28,7 @@ RUN                                                                             
   zip flex bison texinfo glibc-devel.i686 glibc-devel.x86_64                                                                           \
   libgcc.i686 libgcc.x86_64 ncurses-devel expat expat-devel curl-devel                                                                 \
   python-setuptools python-hashlib tcl valgrind gdb vim-enhanced                                                                       \
-  libaio libaio-devel doxygen                                                                                                      &&  \
+  libaio libaio-devel doxygen unzip                                                                                                &&  \
   wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm                                                      &&  \
   rpm -Uvh epel-release*                                                                                                           &&  \
   yum install -y python26                                                                                                          &&  \
@@ -40,3 +40,5 @@ RUN                                                                             
   easy_install argparse
 RUN rpm --rebuilddb && yum install -y environment-modules
 RUN rm -f /var/lib/rpm/Pubkeys && rpm --rebuilddb && yum install -y mysql-devel
+ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
+RUN unzip vault.zip && mv ./vault /usr/bin/vault

--- a/slc6-builder/Dockerfile
+++ b/slc6-builder/Dockerfile
@@ -38,3 +38,6 @@ ENV CCTOOLS_VER 5.3.0
 RUN curl http://ccl.cse.nd.edu/software/files/cctools-$CCTOOLS_VER-x86_64-redhat6.tar.gz |  \
     tar -C / --strip-components=1 -xzf - &&                                                 \
     ldconfig
+
+ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
+RUN unzip vault.zip && mv ./vault /usr/bin/vault

--- a/slc7-builder/Dockerfile
+++ b/slc7-builder/Dockerfile
@@ -28,3 +28,5 @@ RUN                                                                             
 
 RUN pip install --upgrade pip six && pip install bernhard
 RUN gem install --no-ri --no-rdoc fpm
+ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
+RUN unzip vault.zip && mv ./vault /usr/bin/vault

--- a/ubuntu1404-builder/Dockerfile
+++ b/ubuntu1404-builder/Dockerfile
@@ -21,3 +21,5 @@ RUN                                                                             
   pip install bernhard
 
 RUN gem install --no-ri --no-rdoc fpm
+ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
+RUN unzip vault.zip && mv ./vault /usr/bin/vault

--- a/ubuntu1510-builder/Dockerfile
+++ b/ubuntu1510-builder/Dockerfile
@@ -10,3 +10,5 @@ RUN \
     libcurl4-openssl-dev flex bison screen tcl tk zip unzip zsh texinfo libncurses5-dev vim-nox \
     valgrind gdb inetutils-ping libperl-dev && \
   apt-get --yes --force-yes clean
+ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
+RUN unzip vault.zip && mv ./vault /usr/bin/vault


### PR DESCRIPTION
This way we can get secrets for publishing to github without having to
deploy them on each machine at the beginning of the job.