### PR TITLE
Build mesos containers using packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@
 - mesos-master: a self contained Mesos Master instance
 - elasticsearch: a customized elasticsearch instance with HEAD and Marvel plugins
   installed.
+
+# Building with docker
+
+Usually you want to build images with:
+
+    docker build -t alisw/<image-name> <image-name>
+
+# Building images with packer
+
+Some of the images now have a packer.json file which allows them to
+be built using hashicorp [packer](www.packer.io). This has the nice
+advantage that we can customize and upload the images in one go.
+To build them:
+
+    brew install packer # > 0.10.0
+    packer build <image-name>/packer.json

--- a/mesos-base/packer.json
+++ b/mesos-base/packer.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "Build a Mesos base image",
+  "variables": {
+    "centos_major": "7",
+    "centos_minor": "2",
+    "mesos_version": "0.27.2",
+    "docker_version": "1.10.3",
+    "project": "alisw"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "centos:centos{{user `centos_major`}}",
+      "commit": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": ["rpm -Uvh http://repos.mesosphere.com/el/{{user `centos_major`}}/noarch/RPMS/mesosphere-el-repo-{{user `centos_major`}}-{{user `centos_minor`}}.noarch.rpm",
+                 "yum update -y && yum install -y mesos-{{user `mesos_version`}} docker-engine-{{user `docker_version`}} && yum clean all -y"]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `project`}}/mesos-base",
+        "tag": "{{user `mesos_version`}}"
+      },
+      "docker-push"
+    ]
+  ]
+}

--- a/mesos-master/packer.json
+++ b/mesos-master/packer.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Build a Mesos master image",
+  "variables": {
+    "centos_major": "7",
+    "centos_minor": "2",
+    "mesos_version": "0.27.2",
+    "docker_version": "1.10.3",
+    "project": "alisw"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "{{user `project`}}/mesos-base:{{user `mesos_version`}}",
+      "commit": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "mesos-master/run.sh",
+      "destination": "/run.sh"
+    },
+    {
+      "type": "shell",
+      "inline": ["yum install -y iptables ca-certificates lxc e2fsprogs && yum clean all -y"]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `project`}}/mesos-master",
+        "tag": "{{user `mesos_version`}}"
+      },
+      "docker-push"
+    ]
+  ]
+}

--- a/mesos-slave/packer.json
+++ b/mesos-slave/packer.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Build a Mesos slave image",
+  "variables": {
+    "centos_major": "7",
+    "centos_minor": "2",
+    "mesos_version": "0.27.2",
+    "docker_version": "1.10.3",
+    "project": "alisw"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "{{user `project`}}/mesos-base:{{user `mesos_version`}}",
+      "commit": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "mesos-slave/run.sh",
+      "destination": "/run.sh"
+    },
+    {
+      "type": "shell",
+      "inline": ["yum install -y iptables ca-certificates lxc e2fsprogs && yum clean all -y"]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `project`}}/mesos-slave",
+        "tag": "{{user `mesos_version`}}"
+      },
+      "docker-push"
+    ]
+  ]
+}


### PR DESCRIPTION
A new way of building mesos containers is now provided via Hashicorp
`packer`. This has the great advantage that it allows building
and pushing at the same time and easy customization e.g. of the
mesos-version.