### PR TITLE
Improve Parrot container

### DIFF
--- a/slc6-cvmfs/Dockerfile
+++ b/slc6-cvmfs/Dockerfile
@@ -13,8 +13,12 @@ RUN curl -L http://xrootd.org/binaries/xrootd-stable-slc6.repo > /etc/yum.repos.
 COPY eos.repo /etc/yum.repos.d/eos.repo
 RUN rpm --rebuilddb && yum install -y eos-client
 
+# Parrot configuration.
 ENV PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES=yes \
     PARROT_CVMFS_REPO=<default-repositories>\ alice-ocdb.cern.ch:url=http://cvmfs-stratum-one.cern.ch/cvmfs/alice-ocdb.cern.ch,pubkey=/etc/cvmfs/keys/cern.ch/cern-it1.cern.ch.pub \
-    HTTP_PROXY=DIRECT;
-ENTRYPOINT [ "parrot_run" ]
-CMD [ "bash" ]
+    HTTP_PROXY=DIRECT; \
+    PARROT_CVMFS_ALIEN_CACHE=/cvmfs_alien_cache
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT [ "entrypoint.sh" ]
+CMD [ "zsh" ]

--- a/slc6-cvmfs/entrypoint.sh
+++ b/slc6-cvmfs/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/zsh -e
+printf "NOTICE: This container has Parrot for CVMFS. Enter a shell with Parrot with: parrot_run zsh\n" >&2
+[[ -d $PARROT_CVMFS_ALIEN_CACHE ]] || \
+  { printf "WARNING: CVMFS cache disabled. Mount a Docker volume to $PARROT_CVMFS_ALIEN_CACHE to enable it.\n" >&2;
+    unset PARROT_CVMFS_ALIEN_CACHE; }
+exec "$@"


### PR DESCRIPTION
* Uses CVMFS alien cache (shared and persistent)
* Parrot is optional and requires running `parrot_run`