### PR TITLE
Add static libs and update Ruby in slc6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
 
   stage "Build containers"
   withEnv([
-        "BRANCH_NAME=${env.BRANCH_NAME}",  
+        "BRANCH_NAME=${env.BRANCH_NAME}",
         "CHANGE_TARGET=${env.CHANGE_TARGET}"]) {
     dir ("docks") {
       checkout scm
@@ -25,11 +25,14 @@ node {
 
         case $BRANCH_NAME in
           master) DOCKER_TAG=latest ;;
-          *) DOCKER_TAG=devel ;;
+          *)      DOCKER_TAG=devel  ;;
         esac
 
         for x in $IMAGES ; do
-          if grep docker_tag "$x/packer.json" ; then
+          if ! test -f $x/packer.json ; then
+            echo "Image $x does not use Packer, skipping test."
+            continue
+          elif grep docker_tag "$x/packer.json" ; then
             packer build -var "docker_tag=${DOCKER_TAG}" "$x/packer.json"
           else
             echo "$x/packer.json does not use docker_tag"

--- a/slc6-builder/Dockerfile
+++ b/slc6-builder/Dockerfile
@@ -1,5 +1,3 @@
-# alisw/slc6-builder:v15
-
 FROM centos:centos6
 
 # Patch redhat-release: pretend to be SLC6
@@ -11,7 +9,9 @@ COPY mock-uname-slc6.sh /bin/uname
 RUN                                                                                         \
   rpm --rebuilddb                                                                        && \
   yum clean all                                                                          && \
-  yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm  && \
+  rpm --import http://apt.sw.be/RPM-GPG-KEY.dag.txt                                      && \
+  yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm                                                 && \
+  yum install -y http://mirror1.hs-esslingen.de/repoforge/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
   yum install -y autoconf automake bc bzip2 bzip2-devel                                     \
       compat-libstdc++-33 curl cvs e2fsprogs e2fsprogs-libs file gcc-c++                    \
       gcc-gfortran git gmp gmp-devel java-1.7.0-openjdk libX11-devel                        \
@@ -23,21 +23,28 @@ RUN                                                                             
       texinfo glibc-devel.i686 libgcc.i686 glibc-devel.x86_64 libgcc.i686                   \
       libgcc.x86_64 ncurses-devel libcurl-devel expat uuid-devel expat-devel                \
       apr-devel subversion-devel cyrus-sasl-md5 file-devel vim-enhanced                     \
-      valgrind gdb swig python-pip protobuf-devel rubygems ruby-devel                    && \
+      valgrind gdb swig python-pip protobuf-devel glibc-static libxml2-static               \
+      openssl-static zlib zlib-static patch readline readline-devel                         \
+      libyaml-devel libffi-devel iconv-devel environment-modules                         && \
+  yum install -y git --enablerepo=rpmforge-extras                                        && \
   yum clean all                                                                          && \
   pip install bernhard
-RUN rpm --rebuilddb && yum install -y rubygems ruby-devel
-RUN gem install --no-ri --no-rdoc fpm
-RUN rpm --rebuilddb &&                                                                                       \
-    rpm --import http://apt.sw.be/RPM-GPG-KEY.dag.txt &&                                                     \
-    yum install -y http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm &&  \
-    yum install -y git --enablerepo=rpmforge-extras
-RUN rpm --rebuilddb && yum install -y environment-modules
+
+RUN curl -L https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip -o vault.zip && \
+    unzip vault.zip && mv ./vault /usr/bin/vault && rm -f vault.zip
 
 ENV CCTOOLS_VER 5.3.0
 RUN curl http://ccl.cse.nd.edu/software/files/cctools-$CCTOOLS_VER-x86_64-redhat6.tar.gz |  \
     tar -C / --strip-components=1 -xzf - &&                                                 \
     ldconfig
 
-ADD https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip vault.zip
-RUN unzip vault.zip && mv ./vault /usr/bin/vault
+RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 && \
+    curl -L get.rvm.io | bash -s stable                        && \
+    bash -c "                                                     \
+      source /etc/profile.d/rvm.sh && rvm install 2.3.0        && \
+      rvm use 2.3.0 --default                                  && \
+      gem install --no-ri --no-rdoc fpm"
+
+COPY entrypoint.sh /usr/local/bin
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+CMD [ "bash" ]

--- a/slc6-builder/entrypoint.sh
+++ b/slc6-builder/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source /etc/profile.d/rvm.sh
+exec "$@"


### PR DESCRIPTION
New `fpm` requires a modern Ruby with no RPM installation. We are using `rvm`
and the environment is loaded automatically via an entrypoint. This is totally
transparent for all our current use cases.