### PR TITLE
Fix aurora setup

### DIFF
--- a/aurora-executor/packer.json
+++ b/aurora-executor/packer.json
@@ -3,12 +3,12 @@
   "variables": {
     "mesos_version": "0.28.2",
     "aurora_version": "0.15.0",
-    "project": "alisw"
+    "DOCKER_HUB_REPO": "alisw"
   },
   "builders": [
     {
       "type": "docker",
-      "image": "{{user `project`}}/mesos-base:{{user `mesos_version`}}",
+      "image": "{{user `DOCKER_HUB_REPO`}}/mesos-base:{{user `mesos_version`}}",
       "commit": true
     }
   ],
@@ -23,7 +23,7 @@
     [
       {
         "type": "docker-tag",
-        "repository": "{{user `project`}}/aurora-executor",
+        "repository": "{{user `DOCKER_HUB_REPO`}}/aurora-executor",
         "tag": "{{user `aurora_version`}}"
       }
     ]

--- a/aurora-scheduler/packer.json
+++ b/aurora-scheduler/packer.json
@@ -3,12 +3,12 @@
   "variables": {
     "mesos_version": "0.28.2",
     "aurora_version": "0.15.0",
-    "project": "alisw"
+    "DOCKER_HUB_REPO": "alisw"
   },
   "builders": [
     {
       "type": "docker",
-      "image": "{{user `project`}}/mesos-base:{{user `mesos_version`}}",
+      "image": "{{user `DOCKER_HUB_REPO`}}/mesos-base:{{user `mesos_version`}}",
       "commit": true
     }
   ],
@@ -28,9 +28,10 @@
     [
       {
         "type": "docker-tag",
-        "repository": "{{user `project`}}/aurora-scheduler",
+        "repository": "{{user `DOCKER_HUB_REPO`}}/aurora-scheduler",
         "tag": "{{user `aurora_version`}}"
-      }
+      },
+      "docker-push"
     ]
   ]
 }

--- a/aurora-scheduler/run.sh
+++ b/aurora-scheduler/run.sh
@@ -5,11 +5,11 @@ mesos-log initialize --path=/var/lib/aurora/scheduler/db && true
 
 /usr/lib/aurora/bin/aurora-scheduler -mesos_master_address=${AURORA_MESOS_MASTERS} \
   -cluster_name=${AURORA_CLUSTER_NAME:-mesos}                  \
-  -serverset_path=/aurora/scheduler                            \
+  -serverset_path=${AURORA_SERVERSET_PATH:-/aurora/scheduler}  \
   -native_log_quorum_size=${QUORUM_SIZE:-1}                    \
   -backup_dir=/var/lib/aurora-backup                           \
   -http_port=8081                                              \
   -native_log_file_path=/var/lib/aurora/scheduler/db           \
-  -thermos_executor_path=${THERMOS_EXECUTOR_PATH:-/dev/null}   \
+  -thermos_executor_path=${THERMOS_EXECUTOR_PATH:-/usr/bin/thermos_executor}  \
   -zk_endpoints=${ZK_ENDPOINTS:-127.0.0.1:2181}                \
-  -native_log_zk_group_path=/aurora/replicated-log
+  -native_log_zk_group_path=${AURORA_NATIVE_LOG_ZK_GROUP_PATH:-/aurora/replicated-log}

--- a/mesos-slave/packer.json
+++ b/mesos-slave/packer.json
@@ -5,12 +5,13 @@
     "centos_minor": "2",
     "mesos_version": "0.28.2",
     "docker_version": "1.11.2",
-    "project": "alisw"
+    "aurora_version": "0.15.0",
+    "DOCKER_HUB_REPO": "alisw"
   },
   "builders": [
     {
       "type": "docker",
-      "image": "{{user `project`}}/mesos-base:{{user `mesos_version`}}",
+      "image": "{{user `DOCKER_HUB_REPO`}}/mesos-base:{{user `mesos_version`}}",
       "commit": true
     }
   ],
@@ -22,14 +23,16 @@
     },
     {
       "type": "shell",
-      "inline": ["yum install -y iptables ca-certificates lxc e2fsprogs && yum clean all -y"]
+      "inline": ["yum install -y cyrus-sasl",
+                 "rpm -Uvh https://bintray.com/apache/aurora/download_file?file_path=centos-7%2Faurora-executor-{{user `aurora_version`}}-1.el7.centos.aurora.x86_64.rpm",
+                 "yum install -y iptables ca-certificates lxc e2fsprogs && yum clean all -y"]
     }
   ],
   "post-processors": [
     [
       {
         "type": "docker-tag",
-        "repository": "{{user `project`}}/mesos-slave",
+        "repository": "{{user `DOCKER_HUB_REPO`}}/mesos-slave",
         "tag": "{{user `mesos_version`}}"
       },
       "docker-push"


### PR DESCRIPTION
- Add aurora package to mesos slave. This is required so that the slave
  can actually launch the executor.
- Improve configurability of aurora-scheduler.