### PR TITLE
Improve alisw/rsync to work for Aurora CI

### DIFF
--- a/rsync/Dockerfile
+++ b/rsync/Dockerfile
@@ -1,7 +1,0 @@
-FROM centos:centos7
-
-# Patch redhat-release: pretend to be SLC7
-RUN yum update -y && yum install -y rsync nc && yum clean all
-ADD run.sh /run.sh
-
-CMD sh -ex /run.sh

--- a/rsync/packer.json
+++ b/rsync/packer.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Build a rsync image",
+  "variables": {
+    "centos_major": "7",
+    "DOCKER_HUB_REPO": "aliswdev"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "centos:centos{{user `centos_major`}}",
+      "commit": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "rsync/run.sh",
+      "destination": "/run.sh"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "yum update -y && yum install -y rsync nc && yum clean all"
+      ]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `DOCKER_HUB_REPO`}}/rsync",
+        "tag": "latest"
+      },
+      "docker-push"
+    ]
+  ]
+}

--- a/rsync/run.sh
+++ b/rsync/run.sh
@@ -1,4 +1,4 @@
-VOLUME=/data/store
+VOLUME=${VOLUME:-/data/store}
 ALLOW=${ALLOW:-192.168.0.0/16 172.16.0.0/12}
 OWNER=${OWNER:-root}
 GROUP=${GROUP:-root}


### PR DESCRIPTION
- Allow specifying the data volume, defaulting to the old /data/store.
- Use packer to create the docker image and remove the old Dockerfile.