### PR TITLE
Move to Mesos 1.0.1

### DIFF
--- a/aurora-executor/packer.json
+++ b/aurora-executor/packer.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Aurora executor",
   "variables": {
-    "mesos_version": "0.28.2",
-    "aurora_version": "0.15.0",
-    "DOCKER_HUB_REPO": "alisw"
+    "mesos_version": "1.0.1",
+    "aurora_version": "0.16.0",
+    "DOCKER_HUB_REPO": "aliswdev"
   },
   "builders": [
     {

--- a/aurora-scheduler/packer.json
+++ b/aurora-scheduler/packer.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Aurora scheduler",
   "variables": {
-    "mesos_version": "0.28.2",
-    "aurora_version": "0.15.0",
-    "DOCKER_HUB_REPO": "alisw"
+    "mesos_version": "1.0.1",
+    "aurora_version": "0.16.0",
+    "DOCKER_HUB_REPO": "aliswdev"
   },
   "builders": [
     {

--- a/aurora-scheduler/run.sh
+++ b/aurora-scheduler/run.sh
@@ -1,22 +1,41 @@
+#!/bin/bash -ex
+AURORA_HOME=/usr/lib/aurora
 AURORA_MESOS_MASTER=${AURORA_MESOS_MASTERS:-zk://127.0.0.1:2181/mesos}
 
 mkdir -p /var/lib/aurora/scheduler/db /var/lib/aurora-backup
 mesos-log initialize --path=/var/lib/aurora/scheduler/db && true
 
-/usr/lib/aurora/bin/aurora-scheduler -mesos_master_address=${AURORA_MESOS_MASTERS}                                 \
-  -cluster_name=${AURORA_CLUSTER_NAME:-mesos}                                                                      \
-  -serverset_path=${AURORA_SERVERSET_PATH:-/aurora/scheduler}                                                      \
-  -native_log_quorum_size=${QUORUM_SIZE:-1}                                                                        \
-  -backup_dir=/var/lib/aurora-backup                                                                               \
-  -http_port=8081                                                                                                  \
-  -native_log_file_path=/var/lib/aurora/scheduler/db                                                               \
-  -thermos_executor_path=${THERMOS_EXECUTOR_PATH:-/usr/bin/thermos_executor}                                       \
-  -zk_endpoints=${ZK_ENDPOINTS:-127.0.0.1:2181}                                                                    \
-  -native_log_zk_group_path=${AURORA_NATIVE_LOG_ZK_GROUP_PATH:-/aurora/replicated-log}                             \
-  ${AURORA_SHIRO_AFTER_AUTH_FILTER:+-shiro_after_auth_filter=${AURORA_SHIRO_AFTER_AUTH_FILTER}}                    \
-  ${AURORA_SHIRO_REALM_MODULES:+-shiro_realm_modules=${AURORA_SHIRO_REALM_MODULES}}                                \
-  ${AURORA_SHIRO_INI_PATH:+-shiro_ini_path=${AURORA_SHIRO_INI_PATH}}                                               \
-  ${AURORA_HTTP_AUTHENTICATION_MECHANISM:+-http_authentication_mechanism=${AURORA_HTTP_AUTHENTICATION_MECHANISM}}  \
-  ${AURORA_ALLOWED_CONTAINER_TYPES:+-allowed_container_types $AURORA_ALLOWED_CONTAINER_TYPES}                      \
-  ${AURORA_REVOCABLE_RESOURCES:+-receive_revocable_resources=$AURORA_REVOCABLE_RESOURCES}                          \
+JAVA_OPTS=(
+  -Xmx2g
+  -Xms2g
+  -XX:+UseG1GC
+  -XX:+UseStringDeduplication
+  # GC tuning, etc.
+)
+
+
+AURORA_FLAGS=(
+  -mesos_master_address=${AURORA_MESOS_MASTERS}
+  -cluster_name=${AURORA_CLUSTER_NAME:-mesos}
+  -serverset_path=${AURORA_SERVERSET_PATH:-/aurora/scheduler}
+  -native_log_quorum_size=${QUORUM_SIZE:-1}
+  -backup_dir=/var/lib/aurora-backup
+  -http_port=8081
+  -native_log_file_path=/var/lib/aurora/scheduler/db
+  -thermos_executor_path=${THERMOS_EXECUTOR_PATH:-/usr/bin/thermos_executor}
+  -zk_endpoints=${ZK_ENDPOINTS:-127.0.0.1:2181}
+  -native_log_zk_group_path=${AURORA_NATIVE_LOG_ZK_GROUP_PATH:-/aurora/replicated-log}
+  -thermos_executor_cpu=0
+  -thermos_executor_ram=128MB
+  -max_schedule_penalty=20secs
+  -min_offer_hold_time=1mins
+  ${AURORA_SHIRO_AFTER_AUTH_FILTER:+-shiro_after_auth_filter=${AURORA_SHIRO_AFTER_AUTH_FILTER}}
+  ${AURORA_SHIRO_REALM_MODULES:+-shiro_realm_modules=${AURORA_SHIRO_REALM_MODULES}}
+  ${AURORA_SHIRO_INI_PATH:+-shiro_ini_path=${AURORA_SHIRO_INI_PATH}}
+  ${AURORA_HTTP_AUTHENTICATION_MECHANISM:+-http_authentication_mechanism=${AURORA_HTTP_AUTHENTICATION_MECHANISM}}
+  ${AURORA_ALLOWED_CONTAINER_TYPES:+-allowed_container_types $AURORA_ALLOWED_CONTAINER_TYPES}
+  ${AURORA_REVOCABLE_RESOURCES:+-receive_revocable_resources=$AURORA_REVOCABLE_RESOURCES}
   ${AURORA_TIER_CONFIG:+-tier_config=$AURORA_TIER_CONFIG}
+)
+
+JAVA_OPTS="${JAVA_OPTS[*]}" exec "$AURORA_HOME/bin/aurora-scheduler" "${AURORA_FLAGS[@]}"

--- a/marathon/packer.json
+++ b/marathon/packer.json
@@ -1,10 +1,10 @@
 {
   "_comment": "Marathon",
   "variables": {
-    "mesos_version": "0.28.2",
+    "mesos_version": "1.0.1",
     "docker_version": "1.11.3",
-    "marathon_version": "1.1.1",
-    "DOCKER_HUB_REPO": "alisw"
+    "marathon_version": "1.3.5",
+    "DOCKER_HUB_REPO": "aliswdev"
   },
   "builders": [
     {

--- a/mesos-master/packer.json
+++ b/mesos-master/packer.json
@@ -3,9 +3,9 @@
   "variables": {
     "centos_major": "7",
     "centos_minor": "2",
-    "mesos_version": "0.28.2",
-    "docker_version": "1.11.3",
-    "project": "alisw"
+    "mesos_version": "1.0.1",
+    "docker_version": "1.11.2",
+    "project": "aliswdev"
   },
   "builders": [
     {
@@ -22,7 +22,10 @@
     },
     {
       "type": "shell",
-      "inline": ["yum install -y iptables ca-certificates lxc e2fsprogs && yum clean all -y"]
+      "inline": [
+        "yum install -y iptables ca-certificates lxc e2fsprogs openssl && yum clean all -y",
+        "mkdir -p /etc/grid-security && openssl req -x509 -newkey rsa:4096 -keyout /etc/grid-security/hostkey.pem -out /etc/grid-security/hostcert.pem -days 365 -nodes -subj '/CN=localhost'"
+      ]
     }
   ],
   "post-processors": [

--- a/mesos-slave/packer.json
+++ b/mesos-slave/packer.json
@@ -3,9 +3,9 @@
   "variables": {
     "centos_major": "7",
     "centos_minor": "2",
-    "mesos_version": "0.28.2",
+    "mesos_version": "1.0.1",
     "docker_version": "1.11.2",
-    "aurora_version": "0.15.0",
+    "aurora_version": "0.16.0",
     "DOCKER_HUB_REPO": "aliswdev"
   },
   "builders": [
@@ -36,7 +36,8 @@
                  "useradd -u 984 -g 984 mesostest",
                  "yum install -y cyrus-sasl",
                  "rpm -Uvh https://bintray.com/apache/aurora/download_file?file_path=centos-7%2Faurora-executor-{{user `aurora_version`}}-1.el7.centos.aurora.x86_64.rpm",
-                 "yum install -y iptables ca-certificates lxc e2fsprogs && yum clean all -y"
+                 "yum install -y iptables ca-certificates lxc e2fsprogs openssl && yum clean all -y",
+                 "mkdir -p /etc/grid-security && openssl req -x509 -newkey rsa:4096 -keyout /etc/grid-security/hostkey.pem -out /etc/grid-security/hostcert.pem -days 365 -nodes -subj '/CN=localhost'"
       ]
     }
   ],


### PR DESCRIPTION
This will upgrade containers to the following versions:

- mesos-master:1.0.1
- mesos-slave:1.0.1
- marathon:1.3.5
- aurora-scheduler:0.16.0
- aurora-executor:0.16.0

Moreover it will generete a self-signed certificate to enable SSL
encryption.