### PR TITLE
Put our SLC5 container on life support

### DIFF
--- a/slc5ng-builder/install_additions.sh
+++ b/slc5ng-builder/install_additions.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+ALTPREFIX=${ALTPREFIX:-/opt/local}
+TMPPREFIX=/tmp/alt
+NJ=$(grep -c bogomips /proc/cpuinfo)
+
+mkdir -p $ALTPREFIX $TMPPREFIX
+
+export PATH=$ALTPREFIX/bin:$PATH
+export LD_LIBRARY_PATH=$ALTPREFIX/lib64:$ALTPREFIX/lib:$LD_LIBRARY_PATH
+
+cd $TMPPREFIX
+
+wget --no-check-certificate https://www.openssl.org/source/openssl-1.0.2n.tar.gz
+wget http://www.linuxfromscratch.org/patches/blfs/svn/openssl-1.0.2n-compat_versioned_symbols-1.patch
+tar xzf openssl*.tar.gz
+pushd openssl-1.0.2n
+  patch -Np1 -i ../openssl-1.0.2n-compat_versioned_symbols-1.patch
+  ./config --prefix=${ALTPREFIX} --openssldir=${ALTPREFIX}/etc/ssl --libdir=lib shared zlib-dynamic
+  make depend
+  make
+  make install
+popd
+
+wget --no-check-certificate https://curl.mirror.anstey.ca/curl-7.58.0.tar.gz
+tar xzf curl*.tar.gz
+pushd curl-7.58.0
+  ./configure --with-ssl=${ALTPREFIX} --prefix=${ALTPREFIX}
+  make -j${NJ}
+  make install
+popd
+
+wget --no-check-certificate https://www.kernel.org/pub/software/scm/git/git-1.9.5.tar.gz
+tar xzf git*.tar.gz
+pushd git-1.9.5
+  ./configure --prefix=${ALTPREFIX} --with-openssl=${ALTPREFIX} --with-curl=${ALTPREFIX}
+  make -j${NJ}
+  make install
+popd
+
+cd /
+rm -rf $TMPPREFIX

--- a/slc5ng-builder/packer.json
+++ b/slc5ng-builder/packer.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "CentOS 5 builder from ALICE with updated Git/OpenSSL",
+  "variables": {
+    "DOCKER_HUB_REPO": "alisw",
+    "ALTPREFIX": "/opt/local"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "alisw/slc5-builder:latest",
+      "commit": true,
+      "changes": [
+        "ENV PATH {{user `ALTPREFIX`}}/bin:/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "ENV LD_LIBRARY_PATH {{user `ALTPREFIX`}}/lib64:{{user `ALTPREFIX`}}/lib"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "install_additions.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `DOCKER_HUB_REPO`}}/slc5ng-builder",
+        "tag": "latest"
+      },
+      "docker-push"
+    ]
+  ]
+}


### PR DESCRIPTION
SLC5 is no longer supported but we still use it for our builds. Now many sites
(including GitHub) use TLSv1.2 which is not supported by the default OpenSSL
version of SLC5: a consequence of this is that all `git clone` commands from
GitHub fail miserably.

This commit adds a custom version of OpenSSL, Curl and Git, picked by default
by every command in the container.