### PR TITLE
Install gettext-devel on SLC7 and SLC8

### DIFF
--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -45,7 +45,8 @@ yum install -y PyYAML bc compat-libstdc++-33 e2fsprogs             \
                kmod-devel motif motif-devel                        \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \
-               libglvnd-opengl tk-devel libfabric-devel sshpass
+               libglvnd-opengl tk-devel libfabric-devel sshpass    \
+               gettext-devel
 
 rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum
 

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -39,7 +39,8 @@ yum install -y bc e2fsprogs                                        \
                libglvnd-opengl tk-devel libfabric-devel sshpass    \
                xorg-x11-server-Xorg xorg-x11-xauth xorg-x11-apps   \
                python2 python2-devel rsync libXrandr-devel         \
-               libXi-devel libXcursor-devel libXinerama-devel
+               libXi-devel libXcursor-devel libXinerama-devel      \
+               gettext-devel
 
 
 rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
The CI builders need this. Installing it here saves annoying workarounds in the aurora job definition, as the latter is also used for the Ubuntu builds.