### PR TITLE
Fix user variable usage in provisioning script

### DIFF
--- a/slc7-builder/packer.json
+++ b/slc7-builder/packer.json
@@ -17,6 +17,9 @@
   "provisioners": [
     {
       "type": "shell",
+      "environment_vars": [
+        "CCTOOLS_VERSION={{user `CCTOOLS_VERSION`}}"
+      ],
       "script": "provision.sh"
     }
   ],

--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -54,7 +54,7 @@ source scl_source enable rh-git218
 source scl_source enable rh-ruby23
 gem install --no-ri --no-rdoc fpm
 
-curl -L https://github.com/cooperative-computing-lab/cctools/archive/release/{{user `CCTOOLS_VERSION`}}.tar.gz -o cctools.tar.gz
+curl -L "https://github.com/cooperative-computing-lab/cctools/archive/release/$CCTOOLS_VERSION.tar.gz" -o cctools.tar.gz
 mkdir cctools && cd cctools
 tar --strip-components=1 -xzf ../cctools.tar.gz
 ./configure --prefix=/usr/local && make -j10 && make install


### PR DESCRIPTION
Apparently, packer doesn't substitute this variable in the script, so assign it to an environment variable first.