### PR TITLE
Install missing required packages on Ubuntu 18.04

### DIFF
--- a/ubuntu1804-builder/provision.sh
+++ b/ubuntu1804-builder/provision.sh
@@ -19,8 +19,10 @@ apt install -y build-essential curl libcurl4-gnutls-dev gfortran swig autoconf \
     bison libperl-dev libbz2-dev liblzma-dev libnanomsg-dev lsb-release rsync  \
     environment-modules libglfw3-dev libtbb-dev libncurses-dev libmotif-dev    \
     linux-headers-5.4.0-54-generic libkmod-dev libpci-dev rubygems-integration \
-    ruby-full git python-pip python-virtualenv python3-dev python3-venv
+    ruby-full git python-pip python-virtualenv python3-dev python3-venv        \
+    python3-pip
 pip2 install --upgrade pip
+pip3 install --upgrade pip
 
 # Don't generate rdoc or ri documentation.
 gem install --document '' fpm


### PR DESCRIPTION
The boost build needs pip3.

I've tested this container by building O2 and AliPhysics in it, both worked.