### PR TITLE
Make packer.json buildable using packer 1.3.4

### DIFF
--- a/curator/packer.json
+++ b/curator/packer.json
@@ -16,7 +16,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "curator/curator.repo",
+      "source": "curator.repo",
       "destination": "/etc/yum.repos.d/curator.repo"
     },
     {

--- a/marathon/packer.json
+++ b/marathon/packer.json
@@ -16,7 +16,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "marathon/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {

--- a/mesos-base/packer.json
+++ b/mesos-base/packer.json
@@ -17,12 +17,12 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "mesos-base/docker.repo",
+      "source": "docker.repo",
       "destination": "/etc/yum.repos.d/docker.repo"
     },
     {
       "type": "file",
-      "source": "mesos-base/cdh.repo",
+      "source": "cdh.repo",
       "destination": "/etc/yum.repos.d/cdh.repo"
     },
     {

--- a/mesos-dns/packer.json
+++ b/mesos-dns/packer.json
@@ -16,7 +16,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "mesos-dns/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {

--- a/mesos-master/packer.json
+++ b/mesos-master/packer.json
@@ -17,7 +17,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "mesos-master/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {

--- a/mesos-slave/packer.json
+++ b/mesos-slave/packer.json
@@ -18,7 +18,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "mesos-slave/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {

--- a/riemann/packer.json
+++ b/riemann/packer.json
@@ -15,7 +15,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "riemann/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {

--- a/rsync/packer.json
+++ b/rsync/packer.json
@@ -14,7 +14,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "rsync/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {

--- a/ubuntu1804-builder/packer.json
+++ b/ubuntu1804-builder/packer.json
@@ -21,7 +21,7 @@
       {
         "type": "docker-tag",
         "repository": "{{user `DOCKER_HUB_REPO`}}/ubuntu1804-builder",
-        "tags": ["latest"]
+        "tag": "latest"
       },
       "docker-push"
     ]

--- a/ubuntu2004-builder/packer.json
+++ b/ubuntu2004-builder/packer.json
@@ -21,7 +21,7 @@
       {
         "type": "docker-tag",
         "repository": "{{user `DOCKER_HUB_REPO`}}/ubuntu2004-builder",
-        "tags": ["latest"]
+        "tag": "latest"
       },
       "docker-push"
     ]

--- a/vault/packer.json
+++ b/vault/packer.json
@@ -16,7 +16,7 @@
   "provisioners": [
     {
       "type": "file",
-      "source": "vault/run.sh",
+      "source": "run.sh",
       "destination": "/run.sh"
     },
     {


### PR DESCRIPTION
This is the version packaged on Ubuntu, and thus the version installed by the GitHub action.

Most changes only make the `packer.json` files compatible with the build procedure used in the GitHub action, by specifying file names relative to the `packer.json` file.

However, for the two newest Ubuntu images, `"tags": ["latest"]` has to be replaced with `"tag": "latest"` as Packer 1.3.4 doesn't support the former.