### PR TITLE
Override SLC7 container entrypoint

### DIFF
--- a/slc7-builder/packer.json
+++ b/slc7-builder/packer.json
@@ -10,7 +10,8 @@
       "image": "centos:7",
       "commit": true,
       "changes": [
-        "CMD [\"bash\"]"
+        "ENTRYPOINT [\"\"]",
+        "CMD [\"/bin/bash\"]"
       ]
     }
   ],


### PR DESCRIPTION
This brings it in line with other images, so that commands can be passed directly to `docker run`, without needing an extra `-c`.

Simply using `ENTRYPOINT []` doesn't override the entrypoint, but this empty string has the desired effect.

Should fix CI build failures in alisw/alibuild#638.