### PR TITLE
Reset SLC8 entrypoint

### DIFF
--- a/slc8-builder/packer.json
+++ b/slc8-builder/packer.json
@@ -9,7 +9,11 @@
     {
       "type": "docker",
       "image": "centos:8",
-      "commit": true
+      "commit": true,
+      "changes": [
+        "ENTRYPOINT [\"\"]",
+        "CMD [\"/bin/bash\"]"
+      ]
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This brings it in line with the SLC7 container, and should fix the error in the GitHub action that builds docker images in this repo.