### PR TITLE
Install gengetopt on SLC7

### DIFF
--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -46,7 +46,7 @@ yum install -y PyYAML bc compat-libstdc++-33 e2fsprogs             \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \
                libglvnd-opengl tk-devel libfabric-devel sshpass    \
-               gettext-devel
+               gettext-devel gengetopt
 
 rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Needed by the [AliGenerators check](https://ali-ci.cern.ch/alice-build-logs/alisw/alidist/2728/e287f45cb6afa98a0cbd0a2f10cc798fe28b9bab/build_AliGenerators_generators/pretty.html).

I couldn't find the `gengetopts` package on SLC8, so I didn't add it there.