### PR TITLE
Add missing dependency to GPUCI container

### DIFF
--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -45,7 +45,7 @@
         "# Install requirements for GPU event display",
         "yum install dnf-plugins-core",
         "yum config-manager --set-enabled powertools",
-        "yum install -y glew-devel",
+        "yum install -y glew-devel freeglut-devel",
 
         "# Install AMD APP Stack",
         "# No longer available from AMD but the newer versions will not work",


### PR DESCRIPTION
Not urgently needed, only for the standalone dependency, but for the next version of the container.