### PR TITLE
Fix setup of Ubuntu 20.04 builder

### DIFF
--- a/ubuntu2004-builder/provision.sh
+++ b/ubuntu2004-builder/provision.sh
@@ -21,7 +21,7 @@ apt install -y build-essential curl libcurl4-gnutls-dev gfortran swig autoconf \
     linux-headers-5.4.0-53-generic libkmod-dev libpci-dev libmotif-dev         \
     git environment-modules libglfw3-dev libtbb-dev libncurses-dev rclone      \
     ruby-full rubygems-integration python3-dev python3-venv python3-pip        \
-    python-is-python3
+    python-is-python3 python2.7 libpython2.7 libsasl2-dev openjdk-8-jdk  # mesos and jenkins
 # Install pip -> pip3, to match python -> python3 from python-is-python3.
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
 

--- a/ubuntu2004-builder/provision.sh
+++ b/ubuntu2004-builder/provision.sh
@@ -18,7 +18,7 @@ apt install -y build-essential curl libcurl4-gnutls-dev gfortran swig autoconf \
     automake autopoint unzip texinfo gettext libtool libtool-bin pkg-config    \
     libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev flex \
     bison libperl-dev libbz2-dev liblzma-dev libnanomsg-dev lsb-release rsync  \
-    linux-headers-5.4.0-53-generic libkmod-dev libpci-dev libmotif-dev         \
+    linux-headers-5.4.0-53-generic libkmod-dev libpci-dev libmotif-dev ed      \
     git environment-modules libglfw3-dev libtbb-dev libncurses-dev rclone      \
     ruby-full rubygems-integration python3-dev python3-venv python3-pip        \
     python-is-python3 python2.7 libpython2.7 libsasl2-dev openjdk-8-jdk  # mesos and jenkins

--- a/ubuntu2004-builder/provision.sh
+++ b/ubuntu2004-builder/provision.sh
@@ -28,7 +28,6 @@ update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
 # Don't generate rdoc or ri documentation.
 gem install --no-document fpm
 
-curl -L https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip -o vault.zip
-unzip vault.zip
-mv -nv ./vault /usr/bin/vault
-rm -fv vault.zip
+curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
+unzip /tmp/vault.zip vault -d /usr/bin/
+rm -v /tmp/vault.zip


### PR DESCRIPTION
The docker image builds O2 v1.3.0 successfully on my machine, so I'll try to use it to create an Ubuntu 20.04 CI check soon.