### PR TITLE
Update slc8-gpu-builder: Add binary build of clang13 trunk for OpenCL 2

### DIFF
--- a/slc8-gpu-builder/llvm-spirv
+++ b/slc8-gpu-builder/llvm-spirv
@@ -1,3 +1,0 @@
-#!/bin/bash
-cat $1 > `echo $2 | sed "s/-o=//"`
-exit 0

--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -1,9 +1,7 @@
 {
   "_comment": "CentOS 8 GPU builder X-enabled CUDA11.2-enabled AMD ROCm 4.0.0-enabled",
   "variables": {
-    "DOCKER_HUB_REPO": "alisw",
-    "CUDA_PKG_VERSION": "11-2-11.2.*",
-    "NVIDIA_GPGKEY_SUM": "d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5"
+    "DOCKER_HUB_REPO": "alisw"
   },
   "builders": [
     {
@@ -11,7 +9,7 @@
       "image": "alisw/slc8-builder:latest",
       "commit": true,
       "changes": [
-        "ENV CMAKE_PREFIX_PATH=/opt/rocm/lib/cmake",
+        "ENV CMAKE_PREFIX_PATH=/opt/rocm/lib/cmake:/opt/clang/lib/cmake",
         "ENV AMDAPPSDKROOT=/opt/amd-app/",
         "ENV PATH=\"${PATH}:/usr/local/cuda/bin\"",
         "ENV ALIBUILD_O2_FORCE_GPU=1"
@@ -31,63 +29,12 @@
     },
     {
       "type": "file",
-      "source": "llvm-spirv",
-      "destination": "/usr/bin/llvm-spirv"
-    },
-    {
-      "type": "file",
       "source": "rocm.patch",
       "destination": "/rocm.patch"
     },
     {
       "type": "shell",
-      "inline": [
-        "# Install requirements for GPU event display",
-        "yum install dnf-plugins-core",
-        "yum config-manager --set-enabled powertools",
-        "yum install -y glew-devel freeglut-devel lsof",
-
-        "# Install AMD APP Stack",
-        "# No longer available from AMD but the newer versions will not work",
-        "curl -Lo sdk.tbz2 https://sourceforge.net/projects/nicehashsgminerv5viptools/files/APP%20SDK%20A%20Complete%20Development%20Platform/AMD%20APP%20SDK%203.0%20for%2064-bit%20Linux/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2/download",
-        "tar -xjvf sdk.tbz2",
-        "./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh --noexec --target /opt/amd-app",
-        "rm -rf ./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh sdk.tbz2",
-        "# Avoid file collisions between AMD APP and AMD ROCm stack",
-        "mkdir -p /etc/OpenCL/vendors && echo /opt/amd-app/lib/x86_64/sdk/libamdocl64-app.so > /etc/OpenCL/vendors/amdocl64-app.icd",
-        "mv /opt/amd-app/lib/x86_64/sdk/libamdocl64{,-app}.so",
-        "echo /opt/amd-app/lib/x86_64/ > /etc/ld.so.conf.d/amd-app-sdk.conf",
-
-        "# Install NVIDIA CUDA Stack",
-        "curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA",
-        "echo \"{{user `NVIDIA_GPGKEY_SUM`}}  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA\" | sha256sum -c --strict -",
-        "yum install -y cuda-cudart-{{user `CUDA_PKG_VERSION`}} cuda-compat-11-2-* && \\",
-        "ln -s cuda-11.2 /usr/local/cuda && \\",
-        "rm -rf /var/cache/yum/*",
-        "echo \"/usr/local/nvidia/lib\" >> /etc/ld.so.conf.d/nvidia.conf && \\",
-        "echo \"/usr/local/nvidia/lib64\" >> /etc/ld.so.conf.d/nvidia.conf",
-        "export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}",
-        "export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64",
-        "yum install -y cuda-libraries-{{user `CUDA_PKG_VERSION`}} cuda-nvtx-{{user `CUDA_PKG_VERSION`}} && \\",
-        "rm -rf /var/cache/yum/*",
-        "yum install -y cuda-libraries-devel-{{user `CUDA_PKG_VERSION`}} cuda-nvml-devel-{{user `CUDA_PKG_VERSION`}} \\",
-        "               cuda-minimal-build-{{user `CUDA_PKG_VERSION`}} cuda-command-line-tools-{{user `CUDA_PKG_VERSION`}}",
-        "rm -rf /var/cache/yum/*",
-
-        "# Install AMD ROCm stack",
-        "# Notice we do not need the version for ROCM because we target a specific distribution in rocm.repo",
-        "yum install -y hip-rocclr rocm-clang-ocl ocl-icd ocl-icd-devel hipcub rocthrust rocm-dev",
-        "rm -rf /var/cache/yum/*",
-        "# Remove clang-ocl binary, since it is currently broken, to avoid automatic pic up",
-        "rm /opt/rocm/bin/clang-ocl",
-        "# Fix some errors in current ROCm",
-        "cd /",
-        "patch -p0 < rocm.patch",
-        "rm rocm.patch",
-
-        "export LIBRARY_PATH=/usr/local/cuda/lib64/stubs",
-        "ldconfig"
-      ]
+      "script": "provision.sh"
     }
   ],
   "post-processors": [

--- a/slc8-gpu-builder/provision.sh
+++ b/slc8-gpu-builder/provision.sh
@@ -1,0 +1,55 @@
+CUDA_PKG_VERSION="11-2-11.2.*"
+NVIDIA_GPGKEY_SUM="d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5"
+
+# Install requirements for GPU event display
+yum install dnf-plugins-core
+yum config-manager --set-enabled powertools
+yum install -y glew-devel freeglut-devel lsof
+
+# Install AMD APP Stack
+# No longer available from AMD but the newer versions will not work
+curl -Lo sdk.tbz2 https://sourceforge.net/projects/nicehashsgminerv5viptools/files/APP%20SDK%20A%20Complete%20Development%20Platform/AMD%20APP%20SDK%203.0%20for%2064-bit%20Linux/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2/download
+tar -xjvf sdk.tbz2
+./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh --noexec --target /opt/amd-app
+rm ./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh sdk.tbz2
+# Avoid file collisions between AMD APP and AMD ROCm stack
+mkdir -p /etc/OpenCL/vendors
+echo /opt/amd-app/lib/x86_64/sdk/libamdocl64-app.so > /etc/OpenCL/vendors/amdocl64-app.icd
+mv /opt/amd-app/lib/x86_64/sdk/libamdocl64{,-app}.so
+echo /opt/amd-app/lib/x86_64/ > /etc/ld.so.conf.d/amd-app-sdk.conf
+
+# Install NVIDIA CUDA Stack
+curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+echo "${NVIDIA_GPGKEY_SUM}  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
+yum install -y cuda-cudart-${CUDA_PKG_VERSION} cuda-compat-11-2-*
+ln -s cuda-11.2 /usr/local/cuda
+rm -rf /var/cache/yum/*
+echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf
+echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+yum install -y cuda-libraries-${CUDA_PKG_VERSION} cuda-nvtx-${CUDA_PKG_VERSION}
+rm -rf /var/cache/yum/*
+yum install -y cuda-libraries-devel-${CUDA_PKG_VERSION} cuda-nvml-devel-${CUDA_PKG_VERSION} \
+               cuda-minimal-build-${CUDA_PKG_VERSION} cuda-command-line-tools-${CUDA_PKG_VERSION}
+rm -rf /var/cache/yum/*
+
+# Install AMD ROCm stack
+# Notice we do not need the version for ROCM because we target a specific distribution in rocm.repo
+yum install -y hip-rocclr rocm-clang-ocl ocl-icd ocl-icd-devel hipcub rocthrust rocm-dev
+rm -rf /var/cache/yum/*
+# Remove clang-ocl binary, since it is currently broken, to avoid automatic pic up
+rm /opt/rocm/bin/clang-ocl
+# Fix some errors in current ROCm
+cd /
+patch -p0 < rocm.patch
+rm rocm.patch
+
+# Install clang trunk for OpenCL2 compilation
+curl -Lo clang13.tar.bz2 https://qon.jwdt.org/nmls/clang13.tar.bz2
+tar -jxf clang13.tar.bz2 -C /opt/
+rm clang13.tar.bz2
+ln -s /opt/clang/bin/llvm-spirv /usr/bin/
+
+export LIBRARY_PATH=/usr/local/cuda/lib64/stubs
+ldconfig


### PR DESCRIPTION
@TimoWilken : Could you once again update and deploy the GPU CI container?
We need a newer version of clang and the llvm-spirv translater than released. Compiling during docker creation takes ages, and I had to do some manual tweaks, in particular CC8 is lacking some build-requirements. Thus I created a binary version, which is just downloaded and unpacked. We can clean this up with the next clang release.

@ktf : This should fix the issue with the OpenCL warning you reported, and some more OpenCL related issues.