### PR TITLE
Install s3cmd in all CI builders

### DIFF
--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -46,7 +46,7 @@ yum install -y PyYAML bc compat-libstdc++-33 e2fsprogs             \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \
                libglvnd-opengl tk-devel libfabric-devel sshpass    \
-               gettext-devel rclone
+               gettext-devel rclone s3cmd
 
 rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum
 

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -40,7 +40,7 @@ yum install -y bc e2fsprogs                                        \
                xorg-x11-server-Xorg xorg-x11-xauth xorg-x11-apps   \
                python2 python2-devel rsync libXrandr-devel         \
                libXi-devel libXcursor-devel libXinerama-devel      \
-               gettext-devel rclone
+               gettext-devel rclone s3cmd
 
 alternatives --set python /usr/bin/python3
 

--- a/slc8-gpu-builder/provision.sh
+++ b/slc8-gpu-builder/provision.sh
@@ -4,7 +4,7 @@ NVIDIA_GPGKEY_SUM="d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4
 # Install requirements for GPU event display
 yum install dnf-plugins-core
 yum config-manager --set-enabled powertools
-yum install -y glew-devel freeglut-devel lsof s3cmd
+yum install -y glew-devel freeglut-devel lsof
 
 # Install AMD APP Stack
 # No longer available from AMD but the newer versions will not work


### PR DESCRIPTION
The slc8-gpu image needs it for Jenkins builds. Installing it in slc8 means it is also available in slc8-gpu. slc7 needs s3cmd for the RPM publishing script.