### PR TITLE
Add apr-util-devel & cyrus-sasl-devel to slc8 env

### DIFF
--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -40,7 +40,8 @@ yum install -y bc e2fsprogs                                        \
                xorg-x11-server-Xorg xorg-x11-xauth xorg-x11-apps   \
                python2 python2-devel rsync libXrandr-devel         \
                libXi-devel libXcursor-devel libXinerama-devel      \
-               gettext-devel rclone s3cmd
+               gettext-devel rclone s3cmd apr-util-devel           \
+               cyrus-sasl-devel 
 
 alternatives --set python /usr/bin/python3
 


### PR DESCRIPTION
This is needed by the updated Mesos recipe on CentOS 8