### PR TITLE
Install git 2.32.0 in slc8-gpu-builder

### DIFF
--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -1,7 +1,8 @@
 {
   "_comment": "CentOS 8 GPU builder X-enabled CUDA11.3-enabled AMD ROCm 4.1.1-enabled",
   "variables": {
-    "DOCKER_HUB_REPO": "alisw"
+    "DOCKER_HUB_REPO": "alisw",
+    "GIT_VERSION": "2.32.0"
   },
   "builders": [
     {
@@ -34,6 +35,9 @@
     },
     {
       "type": "shell",
+      "environment_vars": [
+        "GIT_VERSION={{user `GIT_VERSION`}}"
+      ],
       "script": "provision.sh"
     }
   ],

--- a/slc8-gpu-builder/provision.sh
+++ b/slc8-gpu-builder/provision.sh
@@ -59,3 +59,13 @@ rm rocm.tar.bz2
 
 export LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 ldconfig
+
+# A recent git version (>= 2.31.0) is required for specifying git config
+# using environment variables.
+curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
+cd "/tmp/git-$GIT_VERSION"
+make prefix=/usr/local all
+make prefix=/usr/local install
+cd /
+rm -rf "/tmp/git-$GIT_VERSION"
+[ "$(git --version)" = "git version $GIT_VERSION" ]


### PR DESCRIPTION
This is needed for the fullCI builder, so that it understands `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_<n>`, `GIT_CONFIG_VALUE_<n>` environment variables, which are used to pass a credential file for cloning TpcFecUtils.