### PR TITLE
Clean up build recipes

### DIFF
--- a/cs8-builder/packer.json
+++ b/cs8-builder/packer.json
@@ -1,9 +1,7 @@
 {
   "_comment": "CentOS Stream 8 builder X-enabled",
   "variables": {
-    "DOCKER_HUB_REPO": "alisw",
-    "CCTOOLS_VERSION": "6.2.9",
-    "EPEL_VERSION": "8"
+    "DOCKER_HUB_REPO": "alisw"
   },
   "builders": [
     {

--- a/cs8-builder/provision.sh
+++ b/cs8-builder/provision.sh
@@ -6,15 +6,16 @@ useradd -rmUu 982 mesosdaq
 useradd -rmUu 983 mesosuser
 useradd -rmUu 984 mesostest
 
-rpmdb --rebuilddb
-yum clean all
-rm -rf /var/cache/yum
+wipeyum () {
+  rpmdb --rebuilddb
+  yum clean all
+  rm -rf /var/cache/yum
+}
 
-yum install -y epel-release
-yum install -y dnf-plugins-core
+wipeyum
+yum install -y epel-release dnf-plugins-core
 yum config-manager --set-enabled powertools
 yum update -y
-
 dnf group install -y 'Development Tools'
 yum install -y bc e2fsprogs                                        \
                e2fsprogs-libs git java-1.8.0-openjdk libXmu libXpm \
@@ -44,12 +45,10 @@ yum install -y bc e2fsprogs                                        \
 
 alternatives --set python /usr/bin/python3
 
-rpmdb --rebuilddb
-yum clean all
-rm -rf /var/cache/yum
+wipeyum
 
-gem install --no-ri --no-rdoc fpm
+gem install --no-document fpm
 
-curl -L https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip -o /tmp/vault.zip
+curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
 unzip /tmp/vault.zip vault -d /usr/bin/
-rm -vf vault.zip
+rm -v /tmp/vault.zip

--- a/slc8-builder/packer.json
+++ b/slc8-builder/packer.json
@@ -1,9 +1,7 @@
 {
   "_comment": "CentOS 8 builder X-enabled",
   "variables": {
-    "DOCKER_HUB_REPO": "alisw",
-    "CCTOOLS_VERSION": "6.2.9",
-    "EPEL_VERSION": "8"
+    "DOCKER_HUB_REPO": "alisw"
   },
   "builders": [
     {

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -1,22 +1,23 @@
-groupadd -g 980 mesosalien
-useradd -u 980 -g 980 mesosalien
-groupadd -g 981 mesosci
-useradd -u 981 -g 981 mesosci
-groupadd -g 982 mesosdaq
-useradd -u 982 -g 982 mesosdaq
-groupadd -g 983 mesosuser
-useradd -u 983 -g 983 mesosuser
-groupadd -g 984 mesostest
-useradd -u 984 -g 984 mesostest
+#!/bin/sh -ex
 
-rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum
+useradd -rmUu 980 mesosalien
+useradd -rmUu 981 mesosci
+useradd -rmUu 982 mesosdaq
+useradd -rmUu 983 mesosuser
+useradd -rmUu 984 mesostest
 
-yum install -y epel-release
-yum install -y dnf-plugins-core
+wipeyum () {
+  rpmdb --rebuilddb
+  yum clean all
+  rm -rf /var/cache/yum
+}
+
+wipeyum
+
+yum install -y epel-release dnf-plugins-core
 yum config-manager --set-enabled powertools
 yum update -y
-
-dnf group install -y "Development Tools"
+yum groups install -y 'Development Tools'
 yum install -y bc e2fsprogs                                        \
                e2fsprogs-libs git java-1.8.0-openjdk libXmu libXpm \
                perl-ExtUtils-Embed rpm-build screen tcl tcsh tk    \
@@ -33,7 +34,7 @@ yum install -y bc e2fsprogs                                        \
                python3-requests libuuid-devel createrepo           \
                protobuf-devel python3-pip python3-devel            \
                mariadb-devel kernel-devel pciutils-devel           \
-               kmod-devel motif motif-devel pigz                   \
+               kmod-devel motif motif-devel pigz glew-devel        \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \
                libglvnd-opengl tk-devel libfabric-devel sshpass    \
@@ -45,9 +46,10 @@ yum install -y bc e2fsprogs                                        \
 
 alternatives --set python /usr/bin/python3
 
-rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum
+wipeyum
 
-gem install --no-ri --no-rdoc fpm
+gem install --no-document fpm
 
-curl -L https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip -o vault.zip
-unzip vault.zip && mv ./vault /usr/bin/vault && rm -f vault.zip
+curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
+unzip /tmp/vault.zip vault -d /usr/bin/
+rm -v /tmp/vault.zip

--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -2,6 +2,8 @@
   "_comment": "CentOS 8 GPU builder X-enabled CUDA11.3-enabled AMD ROCm 4.1.1-enabled",
   "variables": {
     "DOCKER_HUB_REPO": "alisw",
+    "CUDA_PKG_VERSION": "11-3-11.3.*",
+    "NVIDIA_GPGKEY_SUM": "d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5",
     "GIT_VERSION": "2.32.0"
   },
   "builders": [
@@ -36,6 +38,8 @@
     {
       "type": "shell",
       "environment_vars": [
+        "CUDA_PKG_VERSION={{user `CUDA_PKG_VERSION`}}",
+        "NVIDIA_GPGKEY_SUM={{user `NVIDIA_GPGKEY_SUM`}}",
         "GIT_VERSION={{user `GIT_VERSION`}}"
       ],
       "script": "provision.sh"

--- a/slc8-gpu-builder/provision.sh
+++ b/slc8-gpu-builder/provision.sh
@@ -1,64 +1,57 @@
-CUDA_PKG_VERSION="11-3-11.3.*"
-NVIDIA_GPGKEY_SUM="d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5"
-
-# Install requirements for GPU event display
-yum install dnf-plugins-core
-yum config-manager --set-enabled powertools
-yum install -y glew-devel freeglut-devel lsof
+#!/bin/sh -ex
 
 # Install AMD APP Stack
 # No longer available from AMD but the newer versions will not work
-curl -Lo sdk.tbz2 https://sourceforge.net/projects/nicehashsgminerv5viptools/files/APP%20SDK%20A%20Complete%20Development%20Platform/AMD%20APP%20SDK%203.0%20for%2064-bit%20Linux/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2/download
-tar -xjvf sdk.tbz2
+curl -fsSL https://sourceforge.net/projects/nicehashsgminerv5viptools/files/APP%20SDK%20A%20Complete%20Development%20Platform/AMD%20APP%20SDK%203.0%20for%2064-bit%20Linux/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2/download |
+  tar -xjv
 ./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh --noexec --target /opt/amd-app
-rm ./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh sdk.tbz2
+rm -v AMD-APP-SDK-v3.0.130.136-GA-linux64.sh
 # Avoid file collisions between AMD APP and AMD ROCm stack
 mkdir -p /etc/OpenCL/vendors
 echo /opt/amd-app/lib/x86_64/sdk/libamdocl64-app.so > /etc/OpenCL/vendors/amdocl64-app.icd
-mv /opt/amd-app/lib/x86_64/sdk/libamdocl64{,-app}.so
+mv -v /opt/amd-app/lib/x86_64/sdk/libamdocl64.so \
+      /opt/amd-app/lib/x86_64/sdk/libamdocl64-app.so
 echo /opt/amd-app/lib/x86_64/ > /etc/ld.so.conf.d/amd-app-sdk.conf
 
-# Install NVIDIA CUDA Stack
-curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
+# Install NVIDIA GPG key
+curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/7fa2af80.pub |
+  sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
 echo "${NVIDIA_GPGKEY_SUM}  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
-yum install -y cuda-cudart-${CUDA_PKG_VERSION} cuda-compat-11-3-*
+
+# Install requirements for GPU event display, NVIDIA CUDA and AMD ROCm stacks
+yum install -y freeglut-devel lsof "cuda-cudart-$CUDA_PKG_VERSION" 'cuda-compat-11-3-*'           \
+               "cuda-libraries-$CUDA_PKG_VERSION" "cuda-nvtx-$CUDA_PKG_VERSION"                   \
+               "cuda-libraries-devel-$CUDA_PKG_VERSION" "cuda-nvml-devel-$CUDA_PKG_VERSION"       \
+               "cuda-minimal-build-$CUDA_PKG_VERSION" "cuda-command-line-tools-$CUDA_PKG_VERSION" \
+               hip-rocclr rocm-clang-ocl ocl-icd ocl-icd-devel hipcub rocthrust rocm-dev
+# ROCm: Notice we do not need the version for ROCM because we target a specific distribution in rocm.repo
+
+rpmdb --rebuilddb
+yum clean all
+rm -rf /var/cache/yum
+
+# Set up NVIDIA CUDA stack
 ln -s cuda-11.3 /usr/local/cuda
-rm -rf /var/cache/yum/*
-echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf
-echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+echo /usr/local/nvidia/lib >> /etc/ld.so.conf.d/nvidia.conf
+echo /usr/local/nvidia/lib64 >> /etc/ld.so.conf.d/nvidia.conf
 export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
-yum install -y cuda-libraries-${CUDA_PKG_VERSION} cuda-nvtx-${CUDA_PKG_VERSION}
-rm -rf /var/cache/yum/*
-yum install -y cuda-libraries-devel-${CUDA_PKG_VERSION} cuda-nvml-devel-${CUDA_PKG_VERSION} \
-               cuda-minimal-build-${CUDA_PKG_VERSION} cuda-command-line-tools-${CUDA_PKG_VERSION}
-rm -rf /var/cache/yum/*
 
-# Install AMD ROCm stack
-# Notice we do not need the version for ROCM because we target a specific distribution in rocm.repo
-yum install -y hip-rocclr rocm-clang-ocl ocl-icd ocl-icd-devel hipcub rocthrust rocm-dev
-rm -rf /var/cache/yum/*
-# Remove clang-ocl binary, since it is currently broken, to avoid automatic pic up
-rm /opt/rocm/bin/clang-ocl
+# Remove clang-ocl binary, since it is currently broken, to avoid automatic pick-up
+rm -v /opt/rocm/bin/clang-ocl
 # Fix some errors in current ROCm
-cd /
-patch -p0 < rocm.patch
-rm rocm.patch
+patch -p0 < /rocm.patch
+rm -v /rocm.patch
 
 # Install clang trunk for OpenCL2 compilation
-curl -Lo clang13.tar.bz2 https://qon.jwdt.org/nmls/clang13.tar.bz2
-tar -jxf clang13.tar.bz2 -C /opt/
-rm clang13.tar.bz2
+curl -fsSL https://qon.jwdt.org/nmls/clang13.tar.bz2 | tar -jxC /opt/
 ln -s /opt/clang/bin/llvm-spirv /usr/bin/
 
 # Update ROCm with tarball containing all fixes
-rm -Rf /opt/rocm*
-curl -Lo rocm.tar.bz2 https://qon.jwdt.org/nmls/rocm.tar.bz2
-tar -jxf rocm.tar.bz2 -C /opt/
-rm rocm.tar.bz2
+rm -rf /opt/rocm*
+curl -fsSL https://qon.jwdt.org/nmls/rocm.tar.bz2 | tar -jxC /opt/
 
-export LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-ldconfig
+LIBRARY_PATH=/usr/local/cuda/lib64/stubs ldconfig
 
 # A recent git version (>= 2.31.0) is required for specifying git config
 # using environment variables.


### PR DESCRIPTION
This should speed up container builds. It also makes the scripts a bit easier to maintain.

This gets the slc8-gpu build from 12 mins to 8 mins.