### PR TITLE
Install recent git version in all CI containers

### DIFF
--- a/cs8-builder/packer.json
+++ b/cs8-builder/packer.json
@@ -1,7 +1,8 @@
 {
   "_comment": "CentOS Stream 8 builder X-enabled",
   "variables": {
-    "DOCKER_HUB_REPO": "alisw"
+    "DOCKER_HUB_REPO": "alisw",
+    "GIT_VERSION": "2.32.0"
   },
   "builders": [
     {
@@ -17,6 +18,9 @@
   "provisioners": [
     {
       "type": "shell",
+      "environment_vars": [
+        "GIT_VERSION={{user `GIT_VERSION`}}"
+      ],
       "script": "provision.sh"
     }
   ],

--- a/cs8-builder/provision.sh
+++ b/cs8-builder/provision.sh
@@ -52,3 +52,13 @@ gem install --no-document fpm
 curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
 unzip /tmp/vault.zip vault -d /usr/bin/
 rm -v /tmp/vault.zip
+
+# A recent git version (>= 2.31.0) is required for specifying git config
+# using environment variables.
+curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
+cd "/tmp/git-$GIT_VERSION"
+make prefix=/usr/local -j 10 all
+make prefix=/usr/local install
+cd /
+rm -rf "/tmp/git-$GIT_VERSION"
+[ "$(git --version)" = "git version $GIT_VERSION" ]

--- a/slc7-builder/packer.json
+++ b/slc7-builder/packer.json
@@ -2,7 +2,8 @@
   "_comment": "CentOS 7 builder X-enabled",
   "variables": {
     "DOCKER_HUB_REPO": "alisw",
-    "CCTOOLS_VERSION": "6.2.9"
+    "CCTOOLS_VERSION": "6.2.9",
+    "GIT_VERSION": "2.32.0"
   },
   "builders": [
     {
@@ -19,7 +20,8 @@
     {
       "type": "shell",
       "environment_vars": [
-        "CCTOOLS_VERSION={{user `CCTOOLS_VERSION`}}"
+        "CCTOOLS_VERSION={{user `CCTOOLS_VERSION`}}",
+        "GIT_VERSION={{user `GIT_VERSION`}}"
       ],
       "script": "provision.sh"
     }

--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -69,3 +69,13 @@ which work_queue_worker
 curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
 unzip /tmp/vault.zip vault -d /usr/bin/
 rm -v /tmp/vault.zip
+
+# A recent git version (>= 2.31.0) is required for specifying git config
+# using environment variables.
+curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
+cd "/tmp/git-$GIT_VERSION"
+make prefix=/usr/local -j 10 all
+make prefix=/usr/local install
+cd /
+rm -rf "/tmp/git-$GIT_VERSION"
+[ "$(git --version)" = "git version $GIT_VERSION" ]

--- a/slc8-builder/packer.json
+++ b/slc8-builder/packer.json
@@ -1,7 +1,8 @@
 {
   "_comment": "CentOS 8 builder X-enabled",
   "variables": {
-    "DOCKER_HUB_REPO": "alisw"
+    "DOCKER_HUB_REPO": "alisw",
+    "GIT_VERSION": "2.32.0"
   },
   "builders": [
     {
@@ -17,6 +18,9 @@
   "provisioners": [
     {
       "type": "shell",
+      "environment_vars": [
+        "GIT_VERSION={{user `GIT_VERSION`}}"
+      ],
       "script": "provision.sh"
     }
   ],

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -53,3 +53,13 @@ gem install --no-document fpm
 curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
 unzip /tmp/vault.zip vault -d /usr/bin/
 rm -v /tmp/vault.zip
+
+# A recent git version (>= 2.31.0) is required for specifying git config
+# using environment variables.
+curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
+cd "/tmp/git-$GIT_VERSION"
+make prefix=/usr/local -j 10 all
+make prefix=/usr/local install
+cd /
+rm -rf "/tmp/git-$GIT_VERSION"
+[ "$(git --version)" = "git version $GIT_VERSION" ]

--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -3,8 +3,7 @@
   "variables": {
     "DOCKER_HUB_REPO": "alisw",
     "CUDA_PKG_VERSION": "11-3-11.3.*",
-    "NVIDIA_GPGKEY_SUM": "d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5",
-    "GIT_VERSION": "2.32.0"
+    "NVIDIA_GPGKEY_SUM": "d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5"
   },
   "builders": [
     {

--- a/slc8-gpu-builder/provision.sh
+++ b/slc8-gpu-builder/provision.sh
@@ -52,13 +52,3 @@ rm -rf /opt/rocm*
 curl -fsSL https://qon.jwdt.org/nmls/rocm.tar.bz2 | tar -jxC /opt/
 
 LIBRARY_PATH=/usr/local/cuda/lib64/stubs ldconfig
-
-# A recent git version (>= 2.31.0) is required for specifying git config
-# using environment variables.
-curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
-cd "/tmp/git-$GIT_VERSION"
-make prefix=/usr/local all
-make prefix=/usr/local install
-cd /
-rm -rf "/tmp/git-$GIT_VERSION"
-[ "$(git --version)" = "git version $GIT_VERSION" ]


### PR DESCRIPTION
CS8 needs to clone TpcFecUtils as well, and slc7 will probably need to as well.