### PR TITLE
Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
-# Docker images description
+# ALICE Docker images
 
+- *OS*-builder: the OS images used e.g. in CI, when building for the given OS
+  (e.g. slc7 for CentOS 7)
 - mesos-base: basic mesos installation.
 - mesos-slave: a self contained Mesos Slave instance
 - mesos-master: a self contained Mesos Master instance
 - elasticsearch: a customized elasticsearch instance with HEAD and Marvel plugins
   installed.
 
-# Building with docker
+## Building images with packer
 
-Usually you want to build images with:
+Newer images have a `packer.json` file, which allows them to be built using
+Hashicorp [packer](https://www.packer.io). This has the nice advantage that we
+can customize and upload the images in one go. To build them:
 
-    docker build -t alisw/<image-name> <image-name>
+```bash
+brew install packer # > 0.10.0
+cd <image-name>
+packer build packer.json
+```
 
-# Building images with packer
+If you don't want to upload the finished image to DockerHub (e.g. if you're just
+testing changes to the image, or you don't have the rights to upload), remove
+the `"docker-push"` entry from `"post-processors"` in the `packer.json` you're
+using. (JSON doesn't allow trailing commas in arrays, so don't forget to remove
+the comma as well!)
 
-Some of the images now have a packer.json file which allows them to
-be built using hashicorp [packer](www.packer.io). This has the nice
-advantage that we can customize and upload the images in one go.
-To build them:
+## Building with docker
 
-    brew install packer # > 0.10.0
-    packer build <image-name>/packer.json
+Older images without a `packer.json` can be built with:
+
+```bash
+docker build -t alisw/<image-name> <image-name>
+```


### PR DESCRIPTION
The Packer configuration expects shell scripts in the CWD, so you need to `cd` before building.

I also reordered the sections, as most images are built using Packer, and only some older ones have a Dockerfile.