### PR TITLE
Fix ROCm CC8 repo

### DIFF
--- a/slc8-gpu-builder/rocm.repo
+++ b/slc8-gpu-builder/rocm.repo
@@ -1,5 +1,5 @@
 [ROCm]
 name=ROCm
-baseurl=http://repo.radeon.com/rocm/yum/4.5.2
+baseurl=http://repo.radeon.com/rocm/centos8/4.5.2
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
it seems the `yum` repo we have been using so far is for CC7.
Always worked, so probably no big deal, but for consistency with the EPN, we should switch to the centos8 repo.