### PR TITLE
centos8: add rdma-core-devel to support building of UCX library

### DIFF
--- a/cs8-builder/provision.sh
+++ b/cs8-builder/provision.sh
@@ -41,7 +41,7 @@ yum install -y bc e2fsprogs                                        \
                python2 python2-devel rsync libXrandr-devel         \
                libXi-devel libXcursor-devel libXinerama-devel      \
                gettext-devel rclone s3cmd apr-util-devel           \
-               cyrus-sasl-devel 
+               cyrus-sasl-devel rdma-core-devel
 
 alternatives --set python /usr/bin/python3
 

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -47,7 +47,7 @@ yum install -y bc e2fsprogs                                        \
                python2 python2-devel rsync libXrandr-devel         \
                libXi-devel libXcursor-devel libXinerama-devel      \
                gettext-devel rclone s3cmd apr-util-devel           \
-               cyrus-sasl-devel python3-pyyaml
+               cyrus-sasl-devel python3-pyyaml rdma-core-devel
 
 alternatives --set python /usr/bin/python3
 


### PR DESCRIPTION
This adds missing centos8 package to enable https://github.com/alisw/alidist/pull/3880
