### PR TITLE
Install rdma-core-devel on slc8/cs8

### DIFF
--- a/cs8-builder/provision.sh
+++ b/cs8-builder/provision.sh
@@ -41,7 +41,7 @@ yum install -y bc e2fsprogs                                        \
                python2 python2-devel rsync libXrandr-devel         \
                libXi-devel libXcursor-devel libXinerama-devel      \
                gettext-devel rclone s3cmd apr-util-devel           \
-               cyrus-sasl-devel 
+               cyrus-sasl-devel rdma-core-devel
 
 alternatives --set python /usr/bin/python3
 

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -47,7 +47,7 @@ yum install -y bc e2fsprogs                                        \
                python2 python2-devel rsync libXrandr-devel         \
                libXi-devel libXcursor-devel libXinerama-devel      \
                gettext-devel rclone s3cmd apr-util-devel           \
-               cyrus-sasl-devel python3-pyyaml
+               cyrus-sasl-devel python3-pyyaml rdma-core-devel
 
 alternatives --set python /usr/bin/python3
 


### PR DESCRIPTION
Needed to build UCX, which is needed for datadist: alisw/alidist#3880.

Cc: @davidrohr, as `rdma-core-devel` will propagate to the `slc8-gpu-builder` as well.