### PR TITLE
Preinstall alibuild's requirements for Python 2 and 3 on slc7

### DIFF
--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -17,9 +17,9 @@ yum install -y centos-release-scl http://mirror.switch.ch/ftp/mirror/epel/epel-r
 yum-config-manager --enable rhel-server-rhscl-7-rpms
 yum update -y
 yum groups install -y 'Development Tools' 'X Window System'
-yum install -y rh-ruby23-ruby-devel                                \
-               PyYAML bc compat-libstdc++-33 e2fsprogs             \
-               e2fsprogs-libs git java-1.7.0-openjdk libXmu libXpm \
+yum install -y rh-ruby23-ruby-devel python{27,36}-PyYAML           \
+               bc compat-libstdc++-33 e2fsprogs e2fsprogs-libs git \
+               python2-futures java-1.7.0-openjdk libXmu libXpm    \
                perl-ExtUtils-Embed rpm-build screen tcl tcsh tk    \
                wget which zsh gcc gcc-gfortran gcc-c++             \
                libX11-devel libXpm-devel libXft-devel              \


### PR DESCRIPTION
This makes it easier to spin up the container and start using alibuild immediately.