### PR TITLE
Stop redirecting to logstash

### DIFF
--- a/test-results/default.conf
+++ b/test-results/default.conf
@@ -18,14 +18,6 @@ server {
       proxy_ssl_verify off;
     }
 
-
-    # Redirect github hooks to github
-    location /github {
-      proxy_pass       http://logstash.marathon.mesos:5678;
-      proxy_set_header Host      $host;
-      proxy_set_header X-Real-IP $remote_addr;
-    }
-
     location ~ ^/repo {
       root   /usr/share/nginx/html;
       autoindex on;


### PR DESCRIPTION
Not used any more since log4j.