### PR TITLE
Switch to Almalinux 8.7 / AMD ROCm 5.4.3

### DIFF
--- a/slc8-builder/packer.json
+++ b/slc8-builder/packer.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "CentOS 8 builder X-enabled",
+  "_comment": "Alma 8.7 builder X-enabled",
   "variables": {
     "DOCKER_HUB_REPO": "alisw",
     "GIT_VERSION": "2.32.0"
@@ -7,7 +7,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "centos:8",
+      "image": "almalinux:8.7",
       "commit": true,
       "changes": [
         "ENTRYPOINT [\"\"]",

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -12,11 +12,6 @@ wipeyum () {
   rm -rf /var/cache/yum
 }
 
-# The base centos:8 image has the wrong mirror URLs; they need to point to
-# vault.centos.org instead. We also need to use baseurl= instead of mirrorlist=.
-sed -i 's/mirror\.centos\.org/vault.centos.org/g;
-        s/^#baseurl=/baseurl=/; s/^mirrorlist=/#mirrorlist=/' \
-          /etc/yum.repos.d/CentOS-Linux-*.repo
 wipeyum
 
 yum install -y epel-release dnf-plugins-core

--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "CentOS 8 GPU builder X-enabled CUDA11.7-enabled AMD ROCm 5.1.2-enabled",
+  "_comment": "Alma 8.7 GPU builder X-enabled CUDA12.0-enabled AMD ROCm 5.4.3-enabled",
   "variables": {
     "DOCKER_HUB_REPO": "alisw",
     "CUDA_PKG_VERSION": "12-0-12.0.*",

--- a/slc8-gpu-builder/rocm.repo
+++ b/slc8-gpu-builder/rocm.repo
@@ -1,5 +1,5 @@
 [ROCm]
 name=ROCm
-baseurl=http://repo.radeon.com/rocm/rhel8/5.3.3/main/
+baseurl=http://repo.radeon.com/rocm/rhel8/5.4.3/main/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
@TimoWilken : This is for switching the build / CI containers to Alma.

Could you push a new version, and make one jenkins builder available for us, so we can create and test builds on the EPNs?

What is the strategy to update the CI container to this one? In principle, it should be transparent, but who knows...