### PR TITLE
Downgrade ROCm to 5.4.2 due to regression in 5.4.3

### DIFF
--- a/slc8-gpu-builder/packer.json
+++ b/slc8-gpu-builder/packer.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Alma 8.7 GPU builder X-enabled CUDA12.0-enabled AMD ROCm 5.4.3-enabled",
+  "_comment": "Alma 8.7 GPU builder X-enabled CUDA12.0-enabled AMD ROCm 5.4.2-enabled",
   "variables": {
     "DOCKER_HUB_REPO": "alisw",
     "CUDA_PKG_VERSION": "12-0-12.0.*",

--- a/slc8-gpu-builder/rocm.repo
+++ b/slc8-gpu-builder/rocm.repo
@@ -1,5 +1,5 @@
 [ROCm]
 name=ROCm
-baseurl=http://repo.radeon.com/rocm/rhel8/5.4.3/main/
+baseurl=http://repo.radeon.com/rocm/rhel8/5.4.2/main/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
@TimoWilken : We need to downgrade ROCm in the container. Could you redeploy the CI builders with this container.
For the Jenkins, please still wait a bit. We should update the Jenkins builders on Monday or Tuesday, after the SW update at P2.