### PR TITLE
Install patchelf in build containers

### DIFF
--- a/cs8-builder/provision.sh
+++ b/cs8-builder/provision.sh
@@ -32,7 +32,7 @@ yum install -y bc e2fsprogs                                        \
                ruby-devel uuid-devel environment-modules           \
                python3-requests libuuid-devel createrepo           \
                protobuf-devel python3-pip python3-devel            \
-               mariadb-devel kernel-devel pciutils-devel           \
+               mariadb-devel kernel-devel pciutils-devel patchelf  \
                kmod-devel motif motif-devel pigz glew-devel        \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \

--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -40,7 +40,7 @@ yum install -y rh-ruby23-ruby-devel python{27,36}-PyYAML           \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \
                libglvnd-opengl tk-devel libfabric-devel sshpass    \
-               gettext-devel rclone s3cmd
+               patchelf gettext-devel rclone s3cmd
 wipeyum
 cat << \EOF > /etc/profile.d/enable-alice.sh
 source scl_source enable rh-ruby23

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -33,7 +33,7 @@ yum install -y bc e2fsprogs                                        \
                ruby-devel uuid-devel environment-modules           \
                python3-requests libuuid-devel createrepo           \
                protobuf-devel python3-pip python3-devel            \
-               mariadb-devel kernel-devel pciutils-devel           \
+               mariadb-devel kernel-devel pciutils-devel patchelf  \
                kmod-devel motif motif-devel pigz glew-devel        \
                numactl-devel doxygen graphviz glfw-devel           \
                zlib-devel readline-devel openssh-server            \

--- a/ubuntu1804-builder/provision.sh
+++ b/ubuntu1804-builder/provision.sh
@@ -20,7 +20,7 @@ apt install -y build-essential curl libcurl4-gnutls-dev gfortran swig autoconf \
     environment-modules libglfw3-dev libtbb-dev libncurses-dev libmotif-dev    \
     linux-headers-5.4.0-54-generic libkmod-dev libpci-dev rubygems-integration \
     ruby-full git python-pip python-virtualenv python3-dev python3-venv        \
-    python3-pip rclone
+    python3-pip rclone patchelf
 pip2 install --upgrade pip
 pip3 install --upgrade pip
 

--- a/ubuntu2004-builder/provision.sh
+++ b/ubuntu2004-builder/provision.sh
@@ -14,13 +14,13 @@ export DEBIAN_FRONTEND=noninteractive
 apt update -y
 apt upgrade -y
 apt install -y apt-utils
-apt install -y build-essential curl libcurl4-gnutls-dev gfortran swig autoconf \
-    automake autopoint unzip texinfo gettext libtool libtool-bin pkg-config    \
-    libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev flex \
-    bison libperl-dev libbz2-dev liblzma-dev libnanomsg-dev lsb-release rsync  \
-    linux-headers-5.4.0-53-generic libkmod-dev libpci-dev libmotif-dev ed      \
-    git environment-modules libglfw3-dev libtbb-dev libncurses-dev rclone      \
-    ruby-full rubygems-integration python3-dev python3-venv python3-pip        \
+apt install -y build-essential curl libcurl4-gnutls-dev gfortran swig autoconf     \
+    automake autopoint unzip texinfo gettext libtool libtool-bin pkg-config        \
+    libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev flex     \
+    bison libperl-dev libbz2-dev liblzma-dev libnanomsg-dev lsb-release rsync      \
+    linux-headers-5.4.0-53-generic libkmod-dev libpci-dev libmotif-dev ed          \
+    git environment-modules libglfw3-dev libtbb-dev libncurses-dev rclone patchelf \
+    ruby-full rubygems-integration python3-dev python3-venv python3-pip            \
     python-is-python3 python2.7 libpython2.7 libsasl2-dev openjdk-8-jdk  # mesos and jenkins
 # Install pip -> pip3, to match python -> python3 from python-is-python3.
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100

--- a/ubuntu2204-builder/provision.sh
+++ b/ubuntu2204-builder/provision.sh
@@ -19,7 +19,7 @@ apt install -y build-essential autoconf automake autopoint bison flex \
     texinfo libbz2-dev libcurl4-gnutls-dev libfftw3-dev libglfw3-dev \
     libglu1-mesa-dev libkmod-dev liblzma-dev libmotif-dev \
     libmysqlclient-dev libnanomsg-dev libncurses-dev libpci-dev \
-    libperl-dev libtbb-dev libxml2-dev linux-headers-generic \
+    libperl-dev libtbb-dev libxml2-dev linux-headers-generic patchelf \
     lsb-release swig xorg-dev unzip curl rsync ed git pigz rclone \
     environment-modules ruby-full rubygems-integration python3-dev \
     python3-venv python3-pip python-is-python3 \


### PR DESCRIPTION
This is needed for a change in the Python alidist recipe (https://github.com/alisw/alidist/pull/5008), and would be useful for future patchelf'ing that aliBuild might do for performance.