### PR TITLE
Add Alma 9 build container

### DIFF
--- a/slc9-builder/alice-system-deps.repo
+++ b/slc9-builder/alice-system-deps.repo
@@ -1,0 +1,5 @@
+[alice-system-deps]
+name=ALICE System Dependencies - EL9
+baseurl=https://s3.cern.ch/swift/v1/alibuild-repo/RPMS/o2-full-deps_el9.x86-64/
+enabled=1
+gpgcheck=0

--- a/slc9-builder/packer.json
+++ b/slc9-builder/packer.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Alma 9 builder",
+  "variables": {
+    "REPO": "registry.cern.ch/alisw/slc9-builder",
+    "TAG": "latest"
+  },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "gitlab-registry.cern.ch/linuxsupport/alma9-base",
+      "commit": true,
+      "changes": [
+        "ENTRYPOINT [\"\"]",
+        "CMD [\"/bin/bash\"]"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "alice-system-deps.repo",
+      "destination": "/etc/yum.repos.d/alice-system-deps.repo"
+    },
+    {
+      "type": "shell",
+      "script": "provision.sh"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "docker-tag",
+        "repository": "{{user `REPO`}}",
+        "tag": "{{user `TAG`}}"
+      },
+      "docker-push"
+    ]
+  ]
+}

--- a/slc9-builder/provision.sh
+++ b/slc9-builder/provision.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -ex
+
+useradd -rmUu 980 mesosalien
+useradd -rmUu 981 mesosci
+useradd -rmUu 982 mesosdaq
+useradd -rmUu 983 mesosuser
+useradd -rmUu 984 mesostest
+
+wipednf () {
+  rpmdb --rebuilddb
+  dnf clean all
+  rm -rf /var/cache/yum
+}
+
+wipednf
+
+dnf install -y epel-release dnf-plugins-core
+dnf update -y
+dnf groups install -y 'Development Tools'
+# python3-{pip,setuptools} and s3cmd needed for Jenkins builds.
+dnf install -y alice-o2-full-deps python3-pip python3-setuptools s3cmd
+
+wipednf


### PR DESCRIPTION
This is the `[registry.cern.ch/]alisw/slc9-builder` container.

I've cut down the number of installed packages compared to slc8-builder:

* Build requirements are tracked in alice-o2-full-deps, so reuse that package. This way we also have the same setup in the container and for users' local builds, easing debugging.
* Java is not required since we always use the one from `alidist/jdk.sh`, and JDK 8 is too old to be used for JAliEn anyway.
* The extra development tools and X11 libraries were a holdover from the alidock days, and are not used any more.
* I also removed some RPM repo-specific tools like `fpm` and `createrepo`, since we use the slc8 container for those at the moment, and in future I'd like to move that to a separate `alisw/publisher` container, to save space in this one.

I also based the container on the CERN Alma 9 base image, to have the CERN yum repos already installed in addition to the standard ones.