### PR TITLE
Remove additional version of Git from build containers

### DIFF
--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -67,13 +67,3 @@ which work_queue_worker
 curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
 unzip /tmp/vault.zip vault -d /usr/bin/
 rm -v /tmp/vault.zip
-
-# A recent git version (>= 2.31.0) is required for specifying git config
-# using environment variables.
-curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
-cd "/tmp/git-$GIT_VERSION"
-make prefix=/usr/local -j 10 all
-make prefix=/usr/local install
-cd /
-rm -rf "/tmp/git-$GIT_VERSION"
-[ "$(git --version)" = "git version $GIT_VERSION" ]

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -53,13 +53,3 @@ gem install --no-document fpm
 curl -Lo /tmp/vault.zip https://releases.hashicorp.com/vault/0.5.0/vault_0.5.0_linux_amd64.zip
 unzip /tmp/vault.zip vault -d /usr/bin/
 rm -v /tmp/vault.zip
-
-# A recent git version (>= 2.31.0) is required for specifying git config
-# using environment variables.
-curl -L "https://mirrors.edge.kernel.org/pub/software/scm/git/git-$GIT_VERSION.tar.xz" | tar -xJC /tmp
-cd "/tmp/git-$GIT_VERSION"
-make prefix=/usr/local -j 10 all
-make prefix=/usr/local install
-cd /
-rm -rf "/tmp/git-$GIT_VERSION"
-[ "$(git --version)" = "git version $GIT_VERSION" ]


### PR DESCRIPTION
This was originally needed because the default git did not support the `GIT_*` environment variables used by the CI.

With https://github.com/alisw/alibuild/pull/835 and https://github.com/alisw/ali-bot/pull/1298, this is not needed anymore, so we can stop installing the extra copy of Git.