### PR TITLE
Adapt to use old packer

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -40,7 +40,7 @@ jobs:
           apt install -y software-properties-common
           add-apt-repository universe
           apt install -y docker.io packer
-          packer plugins install github.com/hashicorp/docker
+          # packer plugins install github.com/hashicorp/docker
         env:
           DEBIAN_FRONTEND: noninteractive
 


### PR DESCRIPTION
Do not install the plugin for docker, since ubuntu stuck with a version of packer which has docker integrated and does not support plugins.