### PR TITLE
slc7: Include workaround for fpm and cctools

### DIFF
--- a/slc7-builder/provision.sh
+++ b/slc7-builder/provision.sh
@@ -20,11 +20,8 @@ find /etc/yum.repos.d -name "*.bak" -delete
 yum clean all
 yum update -y
 
-yum install -y centos-release-scl http://mirror.switch.ch/ftp/mirror/epel/epel-release-latest-7.noarch.rpm
-yum-config-manager --enable rhel-server-rhscl-7-rpms
-yum update -y
 yum groups install -y 'Development Tools' 'X Window System'
-yum install -y rh-ruby23-ruby-devel python{27,36}-PyYAML           \
+yum install -y python{27,36}-PyYAML           \
                bc compat-libstdc++-33 e2fsprogs e2fsprogs-libs git \
                python2-futures java-1.7.0-openjdk libXmu libXpm    \
                perl-ExtUtils-Embed rpm-build screen tcl tcsh tk    \
@@ -37,7 +34,7 @@ yum install -y rh-ruby23-ruby-devel python{27,36}-PyYAML           \
                svn cvs flex bison texinfo glibc-devel.i686         \
                glibc-devel.x86_64 libgcc.i686 libgcc.x86_64        \
                ncurses-devel vim-enhanced gdb valgrind swig        \
-               apr-devel subversion-devel cyrus-sasl-md5 rubygems  \
+               apr-devel subversion-devel cyrus-sasl-md5 \
                ruby-devel uuid-devel environment-modules           \
                python-requests libuuid-devel createrepo            \
                protobuf-devel python-pip python-devel              \
@@ -49,21 +46,22 @@ yum install -y rh-ruby23-ruby-devel python{27,36}-PyYAML           \
                libglvnd-opengl tk-devel libfabric-devel sshpass    \
                gettext-devel rclone s3cmd
 wipeyum
-cat << \EOF > /etc/profile.d/enable-alice.sh
-source scl_source enable rh-ruby23
-EOF
 
-set +ex  # scl_source doesn't work with `set -e`
-source scl_source enable rh-ruby23
-set -ex
+gpg2 --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+curl -sSL https://get.rvm.io | bash -s stable
+source /etc/profile.d/rvm.sh
+rvm install ruby 2.4
 
+# Pin some dependencies as fpm doesn't
+gem install dotenv -v 2.7.6
+gem install rexml -v 3.2.5
 gem install --no-document fpm
 
 mkdir /tmp/cctools
 curl -fsSL "https://github.com/cooperative-computing-lab/cctools/archive/release/$CCTOOLS_VERSION.tar.gz" |
   tar --strip-components=1 -xzC /tmp/cctools
 cd /tmp/cctools
-./configure --prefix=/usr/local
+./configure --prefix=/usr/local --with-zlib-path=/usr/lib64
 make -j10
 make install
 cd /


### PR DESCRIPTION
Follow-up to deployment issues in #257, and needed for AliGenerators build. 

Since CentOS 7 EOL the SCL repository is no longer working, which means that a few of our dependencies are now older. 

I'm getting a newer ruby from RVM (which is building it from source), could migrate to building it ourselves if the dependency on RVM is an issue.

Tagging @ktf and @jackal1-66 