### PR TITLE
slc9-arm: Do not rebuild rpm db on provision

### DIFF
--- a/slc9-arm-builder/provision.sh
+++ b/slc9-arm-builder/provision.sh
@@ -6,14 +6,6 @@ useradd -rmUu 982 mesosdaq
 useradd -rmUu 983 mesosuser
 useradd -rmUu 984 mesostest
 
-wipednf () {
-  rpmdb --rebuilddb
-  dnf clean all
-  rm -rf /var/cache/yum
-}
-
-wipednf
-
 dnf install -y epel-release dnf-plugins-core
 
 # Formerly "powertools"; contains some dev tools we need.
@@ -24,5 +16,3 @@ dnf update -y
 dnf groups install -y 'Development Tools'
 # python3-{pip,setuptools} and s3cmd needed for Jenkins builds.
 dnf install -y alice-o2-full-deps python3-pip python3-setuptools s3cmd
-
-wipednf


### PR DESCRIPTION
Removing this because it gives problems when building with Docker's overlayfs

Similar issue: https://github.com/radiasoft/containers/issues/91

strace out:
```strace
renameat(AT_FDCWD, "/var/lib/rpm", AT_FDCWD, "/var/lib/rpmold.68") = -1 EXDEV (Invalid cross-device link)
```
