### PR TITLE
Publisher: Clean up disk space before building

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          apt update -y
-          apt install -y software-properties-common
-          add-apt-repository universe
-          apt install -y docker.io packer
+          sudo apt update -y
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository universe
+          sudo apt install -y docker.io packer
           # packer plugins install github.com/hashicorp/docker
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -37,6 +37,7 @@ jobs:
           sudo rm -rf /opt/ghc || true
           sudo rm -rf /usr/local/.ghcup || true
           sudo docker image prune --all --force || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -20,19 +20,18 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    # GitHub seems to install an odd version of docker on the host, so run in a
-    # container and only connect to the host's docker daemon.
-    container:
-      image: ubuntu:22.04
-      volumes:
-        # Connect to host's docker daemon so we don't run docker inside docker.
-        - /var/run/docker.sock:/var/run/docker.sock
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
+      # Some images are too large and we run out of disk space, so try to free some
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -43,6 +43,7 @@ jobs:
           sudo apt update -y
           sudo apt install -y software-properties-common
           sudo add-apt-repository universe
+          sudo apt-get remove containerd.io
           sudo apt install -y docker.io packer
           # packer plugins install github.com/hashicorp/docker
         env:

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -52,7 +52,7 @@ jobs:
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get update && sudo apt-get install packer
-          packer plugins install docker
+          packer plugins install github.com/hashicorp/docker
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -45,7 +45,7 @@ jobs:
           sudo add-apt-repository universe
           sudo apt-get remove containerd.io
           sudo apt install -y docker.io packer
-          # packer plugins install github.com/hashicorp/docker
+          packer plugins install docker
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -43,8 +43,15 @@ jobs:
           sudo apt update -y
           sudo apt install -y software-properties-common
           sudo add-apt-repository universe
+
+          # containerd.io conflicts with docker.io
           sudo apt-get remove containerd.io
-          sudo apt install -y docker.io packer
+          sudo apt install -y docker.io
+
+          # The packer provided by Ubuntu repos is ancient
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get update && sudo apt-get install packer
           packer plugins install docker
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -28,10 +28,15 @@ jobs:
       - uses: actions/checkout@v3
 
       # Some images are too large and we run out of disk space, so try to free some
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
+      - name: Free disk space
+        run: |
+          # https://github.com/jlumbroso/free-disk-space
+          set -ex
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo docker image prune --all --force || true
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -10,7 +10,7 @@ name: Push Docker image
       image-name:
         description: Docker image to build
         required: true
-        default: slc8-builder
+        default: slc9-builder
 
 permissions:
   contents: read


### PR DESCRIPTION
Some images (like slc9-gpu-builder) are too big for the free runner, so
we need to remove some stuff before, mostly unused language packages

Reference for the free disk space:
https://github.com/actions/runner-images/issues/2840

Builder error message:
```
==> docker:    At least 11799MB more space needed on the / filesystem.
```
