### PR TITLE
slc9-builder: Add GNU `time`

### DIFF
--- a/slc9-builder/provision.sh
+++ b/slc9-builder/provision.sh
@@ -23,6 +23,6 @@ dnf config-manager --set-enabled crb
 dnf update -y
 dnf groups install -y 'Development Tools'
 # python3-{pip,setuptools} and s3cmd needed for Jenkins builds.
-dnf install -y alice-o2-full-deps python3-pip python3-setuptools s3cmd
+dnf install -y alice-o2-full-deps python3-pip python3-setuptools s3cmd time
 
 wipednf


### PR DESCRIPTION
Adding it to fix this error in the DPG tester:

```
/sw/slc9_x86-64/O2/1816-slc9_x86-64-local1/share/scripts/jobutils.sh: line 156: /usr/bin/time: No such file or directory
```

@sawenzel: [we use the binary over the shell buiting because] It provides more information. As a gnu tool it's also platform independent