### PR TITLE
Standardize the slc8 container to use o2-full-deps

### DIFF
--- a/slc8-builder/alice-system-deps.repo
+++ b/slc8-builder/alice-system-deps.repo
@@ -1,0 +1,5 @@
+[alice-system-deps]
+name=ALICE System Dependencies - EL8
+baseurl=https://s3.cern.ch/swift/v1/alibuild-repo/RPMS/o2-full-deps_el8.x86-64/
+enabled=1
+gpgcheck=0

--- a/slc8-builder/packer.json
+++ b/slc8-builder/packer.json
@@ -18,6 +18,11 @@
   ],
   "provisioners": [
     {
+      "type": "file",
+      "source": "alice-system-deps.repo",
+      "destination": "/etc/yum.repos.d/alice-system-deps.repo"
+    },
+    {
       "type": "shell",
       "environment_vars": [
         "GIT_VERSION={{user `GIT_VERSION`}}"

--- a/slc8-builder/provision.sh
+++ b/slc8-builder/provision.sh
@@ -18,31 +18,22 @@ yum install -y epel-release dnf-plugins-core
 yum config-manager --set-enabled powertools
 yum update -y
 yum groups install -y 'Development Tools'
-yum install -y bc e2fsprogs                                        \
-               e2fsprogs-libs git java-1.8.0-openjdk libXmu libXpm \
-               perl-ExtUtils-Embed rpm-build screen tcl tcsh tk    \
-               wget which zsh gcc gcc-gfortran gcc-c++             \
-               libX11-devel libXpm-devel libXft-devel              \
-               libXext-devel redhat-lsb libtool automake autoconf  \
-               libxml2-devel openssl-devel libcurl-devel           \
-               bzip2-devel mesa-libGLU-devel zip perl-libwww-perl  \
-               svn cvs flex bison texinfo glibc-devel.i686         \
-               glibc-devel.x86_64 libgcc.i686 libgcc.x86_64        \
-               ncurses-devel vim-enhanced gdb valgrind swig        \
-               apr-devel subversion-devel cyrus-sasl-md5 rubygems  \
-               ruby-devel uuid-devel environment-modules           \
-               python3-requests libuuid-devel createrepo           \
-               protobuf-devel python3-pip python3-devel            \
-               mariadb-devel kernel-devel pciutils-devel           \
-               kmod-devel motif motif-devel pigz glew-devel        \
+dnf install -y alice-o2-full-deps
+yum install -y bc e2fsprogs e2fsprogs-libs java-1.8.0-openjdk      \
+               libXmu libXpm rpm-build screen tcl tcsh tk wget     \
+               zsh gcc gcc-gfortran gcc-c++ redhat-lsb             \
+               openssl-devel libcurl-devel zip perl-libwww-perl    \
+               svn cvs glibc-devel.i686 glibc-devel.x86_64         \
+               libgcc.i686 libgcc.x86_64 vim-enhanced gdb          \
+               valgrind swig cyrus-sasl-md5 rubygems ruby-devel    \
+               uuid-devel libuuid-devel createrepo protobuf-devel  \
+               python3-pip python3-devel mariadb-devel             \
                numactl-devel doxygen graphviz glfw-devel           \
-               zlib-devel readline-devel openssh-server            \
-               libglvnd-opengl tk-devel libfabric-devel sshpass    \
-               xorg-x11-server-Xorg xorg-x11-xauth xorg-x11-apps   \
-               python2 python2-devel rsync libXrandr-devel         \
-               libXi-devel libXcursor-devel libXinerama-devel      \
-               gettext-devel rclone s3cmd apr-util-devel           \
-               cyrus-sasl-devel python3-pyyaml rdma-core-devel
+               zlib-devel openssh-server libglvnd-opengl           \
+               libfabric-devel sshpass xorg-x11-server-Xorg        \
+               xorg-x11-xauth xorg-x11-apps python2 python2-devel  \
+               rclone s3cmd cyrus-sasl-devel python3-pyyaml        \
+               rdma-core-devel
 
 alternatives --set python /usr/bin/python3
 


### PR DESCRIPTION
Follow up to
https://github.com/AliceO2Group/AliceO2/pull/13315#issuecomment-2245874022

Starting with slc8 so far, I'll repeat this with the builders that are
missing one by one, to minimize breaks
