### PR TITLE
Fix packer in GH action

### DIFF
--- a/.github/workflows/check-image-definitions.yml
+++ b/.github/workflows/check-image-definitions.yml
@@ -19,7 +19,11 @@ jobs:
       - name: Install prerequisites
         run: |
           sudo apt update -y
-          sudo apt install -y packer
+
+          # The packer provided by Ubuntu repos is ancient
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get update && sudo apt-get install packer
           packer plugins install github.com/hashicorp/docker
 
       - name: Validate Packer images


### PR DESCRIPTION
Apparently broken, I'm copying the same workaround from the other action

```
Package packer is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'packer' has no installation candidate
```
