### PR TITLE
Bump to ROCm 6.3.1, fix regex for binary files

### DIFF
--- a/slc9-gpu-builder/amdgpu.repo
+++ b/slc9-gpu-builder/amdgpu.repo
@@ -1,5 +1,5 @@
 [amdgpu]
 name=amdgpu
-baseurl=http://repo.radeon.com/amdgpu/6.2.4/rhel/9.4/main/x86_64/
+baseurl=http://repo.radeon.com/amdgpu/6.3.1/rhel/9.4/main/x86_64/
 enabled=1
 gpgcheck=0

--- a/slc9-gpu-builder/packer.json
+++ b/slc9-gpu-builder/packer.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Alma 9.4 GPU builder X-enabled CUDA12.6-enabled AMD ROCm 6.2.4-enabled",
+  "_comment": "Alma 9.4 GPU builder X-enabled CUDA12.6-enabled AMD ROCm 6.3.1-enabled",
   "variables": {
     "REPO": "registry.cern.ch/alisw/slc9-gpu-builder",
     "TAG": "latest",

--- a/slc9-gpu-builder/provision.sh
+++ b/slc9-gpu-builder/provision.sh
@@ -46,7 +46,7 @@ export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 LIBRARY_PATH=/usr/local/cuda/lib64/stubs ldconfig
 
 # Fix some errors in current ROCm
-sed -i "s/amdgpu-function-calls=false/amdgpu-function-calls=true/g" /opt/rocm/bin/hipcc* /opt/rocm/lib/cmake/hip/*.cmake
+sed -i "s/amdgpu-function-calls=false/amdgpu-function-calls=true /g" /opt/rocm/bin/hipcc* /opt/rocm/lib/cmake/hip/*.cmake
 
 # Remove clang-ocl binary, since it is currently broken, to avoid automatic pick-up
 rm -fv /opt/rocm/bin/clang-ocl /usr/bin/clang-ocl

--- a/slc9-gpu-builder/rocm.repo
+++ b/slc9-gpu-builder/rocm.repo
@@ -1,5 +1,5 @@
 [ROCm]
 name=ROCm
-baseurl=http://repo.radeon.com/rocm/rhel9/6.2.4/main/
+baseurl=http://repo.radeon.com/rocm/rhel9/6.3.1/main/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
@singiamtel : I could not test if this works yet, but should bump ROCm to the version we need and fix the hipcc error.
They switched the perl script to a binary, so we have to change the regex to not change the string length.
If this container builds correctly, could you check if the SLC9-FullCI works with it https://its.cern.ch/jira/browse/O2-5624.