### PR TITLE
Fix alice-github-accounts job

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,3 +1,3 @@
-FROM node
+FROM node:22
 ADD run.sh /
 CMD /run.sh


### PR DESCRIPTION
Seems like we overstayed our welcome in Node 6

Should fix this issue on service start

```
npm ERR! Linux 5.14.0-284.11.1.el9_2.x86_64
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v6.3.1
npm ERR! npm  v3.10.3
npm ERR! code EMISSINGARG

npm ERR! typeerror Error: Missing required argument #1
npm ERR! typeerror     at andLogAndFinish (/usr/local/lib/node_modules/npm/lib/fetch-package-metadata.js:31:3)
npm ERR! typeerror     at fetchPackageMetadata (/usr/local/lib/node_modules/npm/lib/fetch-package-metadata.js:51:22)
npm ERR! typeerror     at resolveWithNewModule (/usr/local/lib/node_modules/npm/lib/install/deps.js:515:12)
npm ERR! typeerror     at /usr/local/lib/node_modules/npm/lib/install/deps.js:516:7
npm ERR! typeerror     at /usr/local/lib/node_modules/npm/node_modules/iferr/index.js:13:50
npm ERR! typeerror     at /usr/local/lib/node_modules/npm/lib/fetch-package-metadata.js:37:12
npm ERR! typeerror     at addRequestedAndFinish (/usr/local/lib/node_modules/npm/lib/fetch-package-metadata.js:67:5)
npm ERR! typeerror     at returnAndAddMetadata (/usr/local/lib/node_modules/npm/lib/fetch-package-metadata.js:121:7)
npm ERR! typeerror     at pickVersionFromRegistryDocument (/usr/local/lib/node_modules/npm/lib/fetch-package-metadata.js:138:20)
npm ERR! typeerror     at /usr/local/lib/node_modules/npm/node_modules/iferr/index.js:13:50
npm ERR! typeerror This is an error with npm itself. Please report this error at:
npm ERR! typeerror     <http://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /src/npm-debug.log
```
