### PR TITLE
slc9-gpu-builder: Add rdma-core-devel

### DIFF
--- a/slc9-gpu-builder/provision.sh
+++ b/slc9-gpu-builder/provision.sh
@@ -34,7 +34,7 @@ dnf install -y freeglut-devel lsof                                              
                "cudnn9-cuda-$CUDA_PKG_VERSION"                                                \
                hip-rocclr ocl-icd ocl-icd-devel hipcub rocthrust rocm-dev hipify-clang        \
                hiprand-devel hipblas-devel hipsparse-devel rocblas-devel rocrand-devel        \
-               miopen-hip-devel hipfft-devel rccl-devel migraphx-devel
+               miopen-hip-devel hipfft-devel rccl-devel migraphx-devel rdma-core-devel
 # ROCm: Notice we do not need the version for ROCM because we target a specific distribution in rocm.repo
 
 # Set up NVIDIA CUDA stack


### PR DESCRIPTION
Required to compile ucx with aliBuild

CC @davidrohr @ehellbar
