### PR TITLE
Add explicit PATH to container

### DIFF
--- a/slc9-builder/packer.json
+++ b/slc9-builder/packer.json
@@ -11,7 +11,8 @@
       "commit": true,
       "changes": [
         "ENTRYPOINT [\"\"]",
-        "CMD [\"/bin/bash\"]"
+        "CMD [\"/bin/bash\"]",
+        "ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       ]
     }
   ],


### PR DESCRIPTION
Workaround for https://github.com/actions/runner/issues/3210 in https://github.com/alisw/alidist/blob/master/.github/workflows/check_untested_pkgs.yml

Fixes:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH
```
